### PR TITLE
Filtering script

### DIFF
--- a/AutoGVP/filter_vcf.sh
+++ b/AutoGVP/filter_vcf.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+vcf_file=$1
+exp_args=("$@")
+
+## get vcf filename
+vcf_filtered_file=$1."filtered.vcf"
+
+echo "vcf file: $vcf_file ";
+
+
+
+# default filters
+cmd="bcftools filter -i 'INFO/AF <=0.01' $vcf_file | bcftools filter -i 'INFO/DP >=15' $vcf_file"
+
+## loop through args for other user-defined filters
+for i in "${exp_args[@]:1}"; do
+  #echo filtering for... $i
+  cmd+=" | bcftools filter -i "$i
+  cmd+=" $vcf_file "
+  #echo $cmd
+done
+
+cmd+=" > $vcf_filtered_file"
+
+echo "cmd: " $cmd
+eval "$cmd"

--- a/AutoGVP/filter_vcf.sh
+++ b/AutoGVP/filter_vcf.sh
@@ -15,7 +15,7 @@ cmd="bcftools filter -i 'INFO/AF <=0.01' $vcf_file | bcftools filter -i 'INFO/DP
 ## loop through args for other user-defined filters
 for i in "${exp_args[@]:1}"; do
   #echo filtering for... $i
-  cmd+=" | bcftools filter -i "$i
+  cmd+=" | bcftools filter -i '$i'"
   cmd+=" $vcf_file "
   #echo $cmd
 done

--- a/AutoGVP/filter_vcf.sh
+++ b/AutoGVP/filter_vcf.sh
@@ -3,7 +3,7 @@ vcf_file=$1
 exp_args=("$@")
 
 ## get vcf filename
-vcf_filtered_file=$1."filtered.vcf"
+vcf_filtered_file=${vcf_file%.vcf*}."filtered.vcf"
 
 echo "vcf file: $vcf_file ";
 


### PR DESCRIPTION
Script that uses bcftools to filter for 1. `INFO/AF`, and 2.` INFO/DP` by default. It also can take in user inputted expressions for filtering. Here is an example:

`bash filter_vcf.sh input/test-filter.vcf 'gnomad_3_1_1_AF_non_cancer=0.1'`

First argument is the vcf file and second arg is additional filter. It writes out to file that it appends with `.filtered.vcf`