### PR TITLE
Unloop address_ambiguous_calls() function

### DIFF
--- a/AutoGVP/01-annotate_variants_CAVATICA_input.R
+++ b/AutoGVP/01-annotate_variants_CAVATICA_input.R
@@ -144,19 +144,21 @@ address_conflicting_intrep <- function(clinvar_anno_vcf_df)
 
 address_ambiguous_calls <- function(results_tab_abridged)
 { ## address ambiguous calls (non L/LB/P/LP/VUS) by taking the InterVar final call
-    for(i in 1:nrow(results_tab_abridged)) 
-    {
-      entry <- results_tab_abridged[i,]
-      if(is.na(entry$final_call) || (entry$final_call !="Pathogenic" && 
-                                    entry$final_call != "Likely_benign" &&  entry$final_call !="Likely_pathogenic"
-                                    && entry$final_call != "Uncertain_significance"  &&  entry$final_call !="Benign"  
-                                    &&  entry$final_call !="Uncertain significance"  &&  entry$final_call !="Likely benign") )
-      {
-        
-        new_call <- str_match(results_tab_abridged[i,]$Intervar_evidence, "InterVar\\:\\s(\\w+\\s\\w+)*")[,2]
-        results_tab_abridged[i,]$final_call = new_call
-      }
-    }
+  
+  results_tab_abridged <- results_tab_abridged %>%
+    dplyr::mutate(new_call = case_when(
+      is.na(final_call) | (final_call !="Pathogenic" & 
+                             final_call != "Likely_benign" &  final_call !="Likely_pathogenic"
+                           & final_call != "Uncertain_significance"  &  final_call !="Benign"  
+                           &  final_call !="Uncertain significance"  &  final_call !="Likely benign") ~ str_match(Intervar_evidence, "InterVar\\:\\s(\\w+\\s\\w+)*")[,2],
+      TRUE ~ NA_character_
+    )) %>%
+    dplyr::mutate(final_call = case_when(
+      !is.na(new_call) ~ new_call,
+      TRUE ~ final_call
+    )) %>%
+    dplyr::select(-new_call)
+  
   return(results_tab_abridged)
 }
 

--- a/AutoGVP/filter_vcf.sh
+++ b/AutoGVP/filter_vcf.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+vcf_file=$1
+exp_args=("$@")
+
+## get vcf filename
+vcf_filtered_file=$1."filtered.vcf"
+
+echo "vcf file: $vcf_file ";
+
+
+
+# default filters
+cmd="bcftools filter -i 'INFO/AF <=0.01' $vcf_file | bcftools filter -i 'INFO/DP >=15' $vcf_file"
+
+## loop through args for other user-defined filters
+for i in "${exp_args[@]:1}"; do
+  #echo filtering for... $i
+  cmd+=" | bcftools filter -i "$i
+  cmd+=" $vcf_file "
+  #echo $cmd
+done
+
+cmd+=" > $vcf_filtered_file"
+
+echo "cmd: " $cmd
+eval "$cmd"

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY scripts/install_bioc.r .
 COPY scripts/install_github.r .
 
 ## install wget
-RUN apt update -y && apt install -y wget bzip2 && apt install -y bcftools 
+RUN apt update -y && apt install -y wget bzip2 && apt install -y bcftools
 
 # install R packages
 RUN ./install_bioc.r \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM rocker/tidyverse:4.2
 MAINTAINER naqvia@chop.edu
 WORKDIR /rocker-build/
+
+ENV BCF_VERSION 1.9
+
 RUN RSPM="https://packagemanager.rstudio.com/cran/2022-10-07" \
   && echo "options(repos = c(CRAN='$RSPM'), download.file.method = 'libcurl')" >> /usr/local/lib/R/etc/Rprofile.site
 
@@ -8,7 +11,7 @@ COPY scripts/install_bioc.r .
 COPY scripts/install_github.r .
 
 ## install wget
-RUN apt update -y && apt install -y wget bzip2
+RUN apt update -y && apt install -y wget bzip2 && apt install -y bcftools 
 
 # install R packages
 RUN ./install_bioc.r \


### PR DESCRIPTION
This PR addresses issue #63 by modifying the `address_ambiguous_calls()` function to act on entire data frame instead of looping over all variants. Please review code, run scripts on test files and ensure output is as expected. 