### PR TITLE
Parse VCF file so that INFO subfields are tab-separated columns

### DIFF
--- a/AutoGVP/parse_vcf.sh
+++ b/AutoGVP/parse_vcf.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+vcf_file=$1
+
+## name output file
+vcf_parsed_file=${vcf_file%.vcf*}."parsed.vcf"
+
+egrep -v "^#" $vcf_file | head -n 2 | awk '{ n=split($8, tmp, /=[^;]*;/); for(i=1; i<n; i++) print tmp[i] }' > subfields.tsv
+
+subfields=$(cat subfields.tsv)
+
+function join_by {
+  local d=${1-} f=${2-}
+  if shift 2; then
+    printf %s "$f" "${@/#/$d}"
+  fi
+}
+
+subfield_list=$(join_by '\t%' $subfields)
+
+all_columns="%CHROM\t%POS\t%ID\t%REF\t%ALT\t%QUAL\t%FILTER\t%${subfield_list}\n"
+
+bcftools query -H -f $all_columns $vcf_file > $vcf_parsed_file

--- a/AutoGVP/parse_vcf.sh
+++ b/AutoGVP/parse_vcf.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
-vcf_file=$1
+vcf_file=test_VEP.vcf
 
 ## name output file
 vcf_parsed_file=${vcf_file%.vcf*}."parsed.vcf"
 
+## Extract list of subfields in INFO column
 egrep -v "^#" $vcf_file | head -n 2 | awk '{ n=split($8, tmp, /=[^;]*;/); for(i=1; i<n; i++) print tmp[i] }' > subfields.tsv
 
 subfields=$(cat subfields.tsv)
 
+# Call function to join subfields 
 function join_by {
   local d=${1-} f=${2-}
   if shift 2; then
@@ -15,8 +17,11 @@ function join_by {
   fi
 }
 
+# Join subfields by '\t%' for bcftools query
 subfield_list=$(join_by '\t%' $subfields)
 
+# Add standard vcf columns to list to parse
 all_columns="%CHROM\t%POS\t%ID\t%REF\t%ALT\t%QUAL\t%FILTER\t%${subfield_list}\n"
 
+# run vcftools query to parse all columns and info subfields, and include header
 bcftools query -H -f $all_columns $vcf_file > $vcf_parsed_file


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

### Purpose/implementation Section

#### What feature is being added or bug is being addressed?

This PR adds `parse_vcf.sh` bash script to parse all columns and info fields from VCF file into tab-separated columns for downstream workflow output generation.  

#### What was your approach?

`parse_vcf.sh` first extracts all INFO subfields and formats into a single character string to be used as input for `bcftools query`. `bcftools query` is used to parse all vcf columns and INFO subfields from vcf file, and output is written as `*.parsed.vcf`. 

#### What GitHub issue does your pull request address?

#73 

### Directions for reviewers. Tell potential reviewers what kind of feedback you are soliciting.

Please run script using the test input vcf file as follows: 

`bash parse_vcf.sh input/test-parsing.vcf`

#### Which areas should receive a particularly close look?

Ensure script runs and that output looks as expected (tab-delimited, one column per INFO subfield)

#### Is there anything that you want to discuss further?

The file column names currently start with `[<column no.>]`. I think this would be easier to remove in a subsequent R script in which this file will be merged with AutoGVP Rscript output. 

#### Documentation Checklist

<!-- Please review and specify if it isn't applicable -->

- [X] The function has examples to showcase the usage 
