### PR TITLE
de-duplicate info field columns in parsing script

### DIFF
--- a/AutoGVP/parse_vcf.sh
+++ b/AutoGVP/parse_vcf.sh
@@ -5,7 +5,7 @@ vcf_file=$1
 vcf_parsed_file=${vcf_file%.vcf*}."parsed.vcf"
 
 ## Extract list of subfields in INFO column
-egrep -v "^#" $vcf_file | head -n 2 | awk '{ n=split($8, tmp, /=[^;]*;/); for(i=1; i<n; i++) print tmp[i] }' > subfields.tsv
+egrep -v "^#" $vcf_file | head -n 1 | awk '{ n=split($8, tmp, /=[^;]*;/); for(i=1; i<n; i++) print tmp[i] }' > subfields.tsv
 
 subfields=$(cat subfields.tsv)
 


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

### Purpose/implementation Section

#### What feature is being added or bug is being addressed?

There was an error in the bash script that resulted in vcf INFO fields being duplicated in separate columns of output

#### What was your approach?

modified code to extract unique info fields

#### What GitHub issue does your pull request address?

NA

### Directions for reviewers. Tell potential reviewers what kind of feedback you are soliciting.

please run following code from `AutoGVP/` directory and ensure that output has unique column names: 

`bash parse_vcf.sh input/test-parsing.vcf`

#### Which areas should receive a particularly close look?

see above

#### Is there anything that you want to discuss further?

No

#### Documentation Checklist

<!-- Please review and specify if it isn't applicable -->

- [X] The function has examples to showcase the usage 
- [ ] Added a vignette

