### PR TITLE
update parsing scripts to retain all info fields

### DIFF
--- a/AutoGVP/parse_vcf.sh
+++ b/AutoGVP/parse_vcf.sh
@@ -2,10 +2,10 @@
 vcf_file=$1
 
 ## name output file
-vcf_parsed_file=${vcf_file%.vcf*}."parsed.vcf"
+vcf_parsed_file=${vcf_file%.vcf*}."parsed.tsv"
 
 ## Extract list of subfields in INFO column
-egrep -v "^#" $vcf_file | head -n 1 | awk '{ n=split($8, tmp, /=[^;]*;/); for(i=1; i<n; i++) print tmp[i] }' > subfields.tsv
+egrep -v "^#" $vcf_file | awk '{ n=split($8, tmp, /=[^;]*;/); for(i=1; i<n; i++) print tmp[i] }' | sort -u > subfields.tsv
 
 subfields=$(cat subfields.tsv)
 


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

### Purpose/implementation Section

#### What feature is being added or bug is being addressed?

This script updates `parse_vcf.sh` so that all INFO fields are retained as columns in output. Previously, only INFO fields present in first row of VCF were extracted, which was resulting in some fields with no values in that row being missed. 

#### What was your approach?

Extracted all INFO field names across all rows and retained only unique values to be used as input for `bcftools query` 

#### What GitHub issue does your pull request address?

#89 

### Directions for reviewers. Tell potential reviewers what kind of feedback you are soliciting.

Run parse script on test file as follows: 

`bash parse_vcf.sh test-parsing.vcf`

#### Which areas should receive a particularly close look?

Confirm that there are 53 columns in tsv output, which corresponds to the number of unique info fields. 

#### Is there anything that you want to discuss further?

No

#### Documentation Checklist

<!-- Please review and specify if it isn't applicable -->

- [X] The function has examples to showcase the usage 

