### PR TITLE
resolve discordant calls between variant_summary and submission_summary

### DIFF
--- a/AutoGVP/01-annotate_variants_CAVATICA_input.R
+++ b/AutoGVP/01-annotate_variants_CAVATICA_input.R
@@ -257,6 +257,8 @@ submission_final_df <- variants_no_conflicts %>%
     ClinicalSignificance = ClinicalSignificance.x,
     ReviewStatus = ReviewStatus.y
   ) %>%
+  dplyr::filter(!is.na(vcf_id)) %>%
+  distinct(vcf_id, .keep_all = T) %>%
   dplyr::select(any_of(c(
     "VariationID", "ClinicalSignificance", "ClinicalSignificance",
     "LastEvaluated", "Description", "SubmittedPhenotypeInfo",

--- a/AutoGVP/01-annotate_variants_CAVATICA_input.R
+++ b/AutoGVP/01-annotate_variants_CAVATICA_input.R
@@ -277,7 +277,7 @@ variants_conflicts_latest <- submission_merged_df %>%
 
 # create final df and take ClinSig calls from submission summary
 submission_final_df <- variants_no_conflicts %>%
-  bind_rows(variants_no_conflict_expert, variants_conflicts_phenoInfo, variants_conflicts_latest) %>%
+  bind_rows(variants_no_conflict_expert, variants_consensus_call, variants_conflicts_phenoInfo, variants_conflicts_latest) %>%
   dplyr::mutate(
     ClinicalSignificance = ClinicalSignificance.x,
     ReviewStatus = ReviewStatus.y

--- a/AutoGVP/01-annotate_variants_CAVATICA_input.R
+++ b/AutoGVP/01-annotate_variants_CAVATICA_input.R
@@ -225,8 +225,8 @@ submission_merged_df <- submission_summary_df %>%
 # Identify VariationIDs with no ClinSig conflicts between variant and submission summary at date last evaluated
 variants_no_conflicts <- submission_merged_df %>%
   group_by(VariationID) %>%
-  dplyr::arrange(mdy(LastEvaluated)) %>%
-  dplyr::slice_tail(n = 1) %>%
+  dplyr::arrange(desc(mdy(LastEvaluated))) %>%
+  dplyr::slice_head(n = 1) %>%
   ungroup() %>%
   filter(ClinicalSignificance.x == ClinicalSignificance.y | is.na(ClinicalSignificance.y) | (grepl("Pathogenic|Likely pathogenic", ClinicalSignificance.x) & grepl("Pathogenic|Likely pathogenic", ClinicalSignificance.y)) | (grepl("Benign|Likely benign", ClinicalSignificance.x) & grepl("Benign|Likely benign", ClinicalSignificance.y)) | (grepl("Uncertain significance", ClinicalSignificance.x) & grepl("Uncertain significance", ClinicalSignificance.y)))
 
@@ -236,8 +236,8 @@ variants_conflicts_phenoInfo <- submission_merged_df %>%
   dplyr::filter(ClinicalSignificance.y != ClinicalSignificance.x) %>%
   dplyr::filter(grepl("Pathogenic|Likely pathogenic", ClinicalSignificance.x) & (!is.na(SubmittedPhenotypeInfo) | !is.na(ReportedPhenotypeInfo))) %>%
   group_by(VariationID) %>%
-  dplyr::arrange(mdy(LastEvaluated)) %>%
-  dplyr::slice_tail(n = 1) %>%
+  dplyr::arrange(desc(mdy(LastEvaluated))) %>%
+  dplyr::slice_head(n = 1) %>%
   ungroup()
 
 # Identify VariationIDs with conflicting ClinSigs, and retain call at last data evaluated
@@ -245,8 +245,8 @@ variants_conflicts_latest <- submission_merged_df %>%
   dplyr::filter(!VariationID %in% c(variants_no_conflicts$VariationID, variants_conflicts_phenoInfo$VariationID)) %>%
   dplyr::filter(ClinicalSignificance.y != ClinicalSignificance.x) %>%
   group_by(VariationID) %>%
-  dplyr::arrange(mdy(LastEvaluated)) %>%
-  dplyr::slice_tail(n = 1) %>%
+  dplyr::arrange(desc(mdy(LastEvaluated))) %>%
+  dplyr::slice_head(n = 1) %>%
   ungroup()
 
 # create final df and take ClinSig calls from submission summary

--- a/AutoGVP/01-annotate_variants_CAVATICA_input.R
+++ b/AutoGVP/01-annotate_variants_CAVATICA_input.R
@@ -277,7 +277,7 @@ variants_conflicts_latest <- submission_merged_df %>%
 
 # create final df and take ClinSig calls from submission summary
 submission_final_df <- variants_no_conflicts %>%
-  bind_rows(variants_no_conflict_expert, variants_consensus_call, variants_conflicts_phenoInfo, variants_conflicts_latest) %>%
+  bind_rows(variants_no_conflict_expert, variants_conflicts_phenoInfo, variants_conflicts_latest) %>%
   dplyr::mutate(ClinicalSignificance = ClinicalSignificance.x,
                 ReviewStatus = ReviewStatus.y) %>%
   distinct(vcf_id, .keep_all = T) %>%

--- a/AutoGVP/01-annotate_variants_CAVATICA_input.R
+++ b/AutoGVP/01-annotate_variants_CAVATICA_input.R
@@ -178,49 +178,93 @@ clinvar_anti_join_vcf_df <- anti_join(clinvar_anno_vcf_df, clinvar_anno_vcf_df, 
   dplyr::rename(rs_id = ID)
 
 
-## get latest calls from submission files
-## get latest calls from submission files
-submission_info_df <- vroom(input_variant_summary,
-  delim = "\t",
-  col_types = c(ReferenceAlleleVCF = "c", AlternateAlleleVCF = "c", PositionVCF = "i", VariationID = "n"),
-  show_col_types = FALSE
+## get latest calls from variant and submission summary files
+variant_summary_df <- vroom(input_variant_summary,
+                            delim = "\t",
+                            col_types = c(ReferenceAlleleVCF = "c", AlternateAlleleVCF = "c", PositionVCF = "i", VariationID = "n"),
+                            show_col_types = FALSE
 ) %>%
+  #retain only variants mapped to hg38
+  dplyr::filter(Assembly == "GRCh38" & ReferenceAlleleVCF != "na" & AlternateAlleleVCF != "na") %>%
   # add vcf id column
   dplyr::mutate(
     vcf_id = str_remove_all(paste(Chromosome, "-", PositionVCF, "-", ReferenceAlleleVCF, "-", AlternateAlleleVCF), " "),
     vcf_id = str_replace_all(vcf_id, "chr", ""),
-    VariationID = as.double(noquote(VariationID))
-  ) %>%
+    VariationID = as.double(noquote(VariationID)),
+    LastEvaluated = case_when(
+      LastEvaluated == "-" ~ NA_character_,
+      TRUE ~ LastEvaluated
+    ))
+
+submission_summary_df <- vroom(input_summary_submission_file,
+                               comment = "#", delim = "\t",
+                               col_names = c(
+                                 "VariationID", "ClinicalSignificance", "DateLastEvaluated",
+                                 "Description", "SubmittedPhenotypeInfo", "ReportedPhenotypeInfo",
+                                 "ReviewStatus", "CollectionMethod", "OriginCounts", "Submitter",
+                                 "SCV", "SubmittedGeneSymbol", "ExplanationOfInterpretation"
+                               ),
+                               show_col_types = F
+)
+
+# remove submissions with missing columns (will have NA SubmittedGeneSymbol)
+submission_summary_df <- submission_summary_df[!is.na(submission_summary_df$SubmittedGeneSymbol),]
+
+# renamed date last evaluated column to match `variant_summary_df`
+submission_summary_df <- submission_summary_df %>%
+  dplyr::mutate(DateLastEvaluated = case_when(
+    DateLastEvaluated == "-" ~ NA_character_,
+    TRUE ~ DateLastEvaluated
+  ))
+
+# merge submission_summary and variant_summary info
+submission_merged_df <- submission_summary_df %>%
+  dplyr::rename("LastEvaluated" = DateLastEvaluated) %>%
+  left_join(variant_summary_df, by = c("VariationID", "LastEvaluated"))
+
+# Identify VariationIDs with no ClinSig conflicts between variant and submission summary at date last evaluated
+variants_no_conflicts <- submission_merged_df %>%
   group_by(VariationID) %>%
+  dplyr::arrange(mdy(LastEvaluated)) %>%
+  dplyr::slice_tail(n = 1) %>%
+  ungroup() %>%
+  filter(ClinicalSignificance.x == ClinicalSignificance.y | is.na(ClinicalSignificance.y) | (grepl("Pathogenic|Likely pathogenic", ClinicalSignificance.x) & grepl("Pathogenic|Likely pathogenic", ClinicalSignificance.y)) | (grepl("Benign|Likely benign", ClinicalSignificance.x) & grepl("Benign|Likely benign", ClinicalSignificance.y)) | (grepl("Uncertain significance", ClinicalSignificance.x) & grepl("Uncertain significance", ClinicalSignificance.y)))
+
+# Identify VariationIDs with conflicting ClinSigs, but where a P-LP call has an associated phenotypeInfo
+variants_conflicts_phenoInfo <- submission_merged_df %>%
+  dplyr::filter(!VariationID %in% variants_no_conflicts$VariationID) %>%
+  dplyr::filter(ClinicalSignificance.y != ClinicalSignificance.x) %>%
+  dplyr::filter(grepl("Pathogenic|Likely pathogenic", ClinicalSignificance.x) & (!is.na(SubmittedPhenotypeInfo) | !is.na(ReportedPhenotypeInfo))) %>%
+  group_by(VariationID) %>%
+  dplyr::arrange(mdy(LastEvaluated)) %>%
   dplyr::slice_tail(n = 1) %>%
   ungroup()
 
-submission_summary_df <- vroom(input_submission_file,
-  comment = "#", delim = "\t",
-  col_names = c(
-    "VariationID", "ClinicalSignificance", "DateLastEvaluated",
-    "Description", "SubmittedPhenotypeInfo", "ReportedPhenotypeInfo",
-    "ReviewStatus", "CollectionMethod", "OriginCounts", "Submitter",
-    "SCV", "SubmittedGeneSymbol", "ExplanationOfInterpretation"
-  ),
-  show_col_types = FALSE
-) %>%
-  dplyr::select("VariationID", "ClinicalSignificance", "DateLastEvaluated") %>%
+# Identify VariationIDs with conflicting ClinSigs, and retain call at last data evaluated
+variants_conflicts_latest <- submission_merged_df %>%
+  dplyr::filter(!VariationID %in% c(variants_no_conflicts$VariationID, variants_conflicts_phenoInfo$VariationID)) %>%
+  dplyr::filter(ClinicalSignificance.y != ClinicalSignificance.x) %>%
   group_by(VariationID) %>%
-  arrange(mdy(DateLastEvaluated)) %>%
+  dplyr::arrange(mdy(LastEvaluated)) %>%
   dplyr::slice_tail(n = 1) %>%
   ungroup()
 
-## join submission files to ensure we have vcf id to match with other tables
-submission_final_df <- inner_join(submission_summary_df, submission_info_df, by = "VariationID")
+# create final df and take ClinSig calls from submission summary
+submission_final_df <- variants_no_conflicts %>%
+  bind_rows(variants_conflicts_phenoInfo, variants_conflicts_latest) %>%
+  dplyr::mutate(ClinicalSignificance = ClinicalSignificance.x,
+                ReviewStatus = ReviewStatus.y) %>%
+  dplyr::select(any_of(c("VariationID", "ClinicalSignificance", "ClinicalSignificance",
+                         "LastEvaluated", "Description", "SubmittedPhenotypeInfo",
+                         "ReportedPhenotypeInfo", "ReviewStatus",
+                         "SubmittedGeneSymbol", "GeneSymbol", "vcf_id")))
 
 ## filter only those variants that need consensus call and find  call in submission table
 entries_for_cc <- filter(clinvar_anno_vcf_df, Stars == "1NR", final_call != "Benign", final_call != "Pathogenic", final_call != "Likely_benign", final_call != "Likely_pathogenic", final_call != "Uncertain_significance")
 
 entries_for_cc_in_submission <- inner_join(submission_final_df, entries_for_cc, by = "vcf_id") %>%
-  dplyr::mutate(final_call = ClinicalSignificance.x) %>%
-  dplyr::select(vcf_id, ClinicalSignificance.x, final_call) %>%
-  dplyr::rename("ClinicalSignificance" = ClinicalSignificance.x)
+  dplyr::mutate(final_call = ClinicalSignificance) %>%
+  dplyr::select(vcf_id, ClinicalSignificance, final_call)
 
 ## one Star cases that are “criteria_provided,_single_submitter” that do NOT have the B, LB, P, LP, VUS call must also go to intervar
 ## modified: any cases that do NOT have the B, LB, P, LP, VUS call must also go to intervar

--- a/AutoGVP/01-annotate_variants_CAVATICA_input.R
+++ b/AutoGVP/01-annotate_variants_CAVATICA_input.R
@@ -277,7 +277,7 @@ variants_conflicts_latest <- submission_merged_df %>%
 
 # create final df and take ClinSig calls from submission summary
 submission_final_df <- variants_no_conflicts %>%
-  bind_rows(variants_no_conflict_expert, variants_conflicts_phenoInfo, variants_conflicts_latest) %>%
+  bind_rows(variants_no_conflict_expert, variants_consensus_call, variants_conflicts_phenoInfo, variants_conflicts_latest) %>%
   dplyr::mutate(ClinicalSignificance = ClinicalSignificance.x,
                 ReviewStatus = ReviewStatus.y) %>%
   distinct(vcf_id, .keep_all = T) %>%

--- a/AutoGVP/01-annotate_variants_CAVATICA_input.R
+++ b/AutoGVP/01-annotate_variants_CAVATICA_input.R
@@ -221,50 +221,70 @@ submission_summary_df <- submission_summary_df %>%
 # merge submission_summary and variant_summary info
 submission_merged_df <- submission_summary_df %>%
   dplyr::rename("LastEvaluated" = DateLastEvaluated) %>%
-  left_join(variant_summary_df, by = c("VariationID", "LastEvaluated"))
+  left_join(variant_summary_df, by = c("VariationID")) %>%
+  dplyr::mutate(LastEvaluated = coalesce(LastEvaluated.x, LastEvaluated.y)) %>%
+  dplyr::filter(!is.na(vcf_id))
 
-# Identify VariationIDs with no ClinSig conflicts between variant and submission summary at date last evaluated
-variants_no_conflicts <- submission_merged_df %>%
+variants_no_conflict_expert <- submission_merged_df %>%
+  filter(ReviewStatus.x == "reviewed by expert panel") %>%
   group_by(VariationID) %>%
-  dplyr::arrange(desc(mdy(LastEvaluated))) %>%
+  dplyr::arrange(desc(mdy(LastEvaluated.x))) %>%
   dplyr::slice_head(n = 1) %>%
   ungroup() %>%
   filter(ClinicalSignificance.x == ClinicalSignificance.y | is.na(ClinicalSignificance.y) | (grepl("Pathogenic|Likely pathogenic", ClinicalSignificance.x) & grepl("Pathogenic|Likely pathogenic", ClinicalSignificance.y)) | (grepl("Benign|Likely benign", ClinicalSignificance.x) & grepl("Benign|Likely benign", ClinicalSignificance.y)) | (grepl("Uncertain significance", ClinicalSignificance.x) & grepl("Uncertain significance", ClinicalSignificance.y)))
 
+# Identify VariationIDs with no ClinSig conflicts between variant and submission summary at date last evaluated
+variants_no_conflicts <- submission_merged_df %>%
+  dplyr::filter(!VariationID %in% variants_no_conflict_expert$VariationID) %>%
+  dplyr::filter(ClinicalSignificance.x == ClinicalSignificance.y | is.na(ClinicalSignificance.y) | (grepl("Pathogenic|Likely pathogenic", ClinicalSignificance.x) & grepl("Pathogenic|Likely pathogenic", ClinicalSignificance.y)) | (grepl("Benign|Likely benign", ClinicalSignificance.x) & grepl("Benign|Likely benign", ClinicalSignificance.y)) | (grepl("Uncertain significance", ClinicalSignificance.x) & grepl("Uncertain significance", ClinicalSignificance.y))) %>%
+  group_by(VariationID) %>%
+  dplyr::arrange(desc(mdy(LastEvaluated.x))) %>%
+  dplyr::slice_head(n = 1) %>%
+  ungroup()
+
+consensus_calls <- submission_merged_df %>%
+  dplyr::filter(!VariationID %in% c(variants_no_conflict_expert$VariationID, variants_no_conflicts$VariationID)) %>%
+  count(VariationID, ClinicalSignificance.x) %>%
+  group_by(VariationID) %>%
+  dplyr::filter(n == max(n)) %>%
+  dplyr::filter(!VariationID %in% VariationID[duplicated(VariationID)])
+
+variants_consensus_call <- submission_merged_df %>%
+  dplyr::filter(glue::glue("{VariationID}-{ClinicalSignificance.x}") %in% glue::glue("{consensus_calls$VariationID}-{consensus_calls$ClinicalSignificance.x}")) %>%
+  group_by(VariationID) %>%
+  dplyr::arrange(desc(mdy(LastEvaluated.x))) %>%
+  dplyr::slice_head(n = 1) %>%
+  ungroup()
+
 # Identify VariationIDs with conflicting ClinSigs, but where a P-LP call has an associated phenotypeInfo
 variants_conflicts_phenoInfo <- submission_merged_df %>%
-  dplyr::filter(!VariationID %in% variants_no_conflicts$VariationID) %>%
+  dplyr::filter(!VariationID %in% c(variants_no_conflict_expert$VariationID, variants_no_conflicts$VariationID, variants_consensus_call$VariationID)) %>%
   dplyr::filter(ClinicalSignificance.y != ClinicalSignificance.x) %>%
-  dplyr::filter(grepl("Pathogenic|Likely pathogenic", ClinicalSignificance.x) & (!is.na(SubmittedPhenotypeInfo) | !is.na(ReportedPhenotypeInfo))) %>%
+  dplyr::filter(grepl("Pathogenic|Likely pathogenic", ClinicalSignificance.x) & (!is.na(SubmittedPhenotypeInfo) | !is.na(ReportedPhenotypeInfo)) & !grepl("not provided|not specified", ReportedPhenotypeInfo)) %>%
   group_by(VariationID) %>%
-  dplyr::arrange(desc(mdy(LastEvaluated))) %>%
+  dplyr::arrange(desc(mdy(LastEvaluated.x))) %>%
   dplyr::slice_head(n = 1) %>%
   ungroup()
 
 # Identify VariationIDs with conflicting ClinSigs, and retain call at last data evaluated
 variants_conflicts_latest <- submission_merged_df %>%
-  dplyr::filter(!VariationID %in% c(variants_no_conflicts$VariationID, variants_conflicts_phenoInfo$VariationID)) %>%
+  dplyr::filter(!VariationID %in% c(variants_no_conflict_expert$VariationID, variants_no_conflicts$VariationID, variants_consensus_call$VariationID, variants_conflicts_phenoInfo$VariationID)) %>%
   dplyr::filter(ClinicalSignificance.y != ClinicalSignificance.x) %>%
   group_by(VariationID) %>%
-  dplyr::arrange(desc(mdy(LastEvaluated))) %>%
+  dplyr::arrange(desc(mdy(LastEvaluated.x))) %>%
   dplyr::slice_head(n = 1) %>%
   ungroup()
 
 # create final df and take ClinSig calls from submission summary
 submission_final_df <- variants_no_conflicts %>%
-  bind_rows(variants_conflicts_phenoInfo, variants_conflicts_latest) %>%
-  dplyr::mutate(
-    ClinicalSignificance = ClinicalSignificance.x,
-    ReviewStatus = ReviewStatus.y
-  ) %>%
-  dplyr::filter(!is.na(vcf_id)) %>%
+  bind_rows(variants_no_conflict_expert, variants_conflicts_phenoInfo, variants_conflicts_latest) %>%
+  dplyr::mutate(ClinicalSignificance = ClinicalSignificance.x,
+                ReviewStatus = ReviewStatus.y) %>%
   distinct(vcf_id, .keep_all = T) %>%
-  dplyr::select(any_of(c(
-    "VariationID", "ClinicalSignificance", "ClinicalSignificance",
-    "LastEvaluated", "Description", "SubmittedPhenotypeInfo",
-    "ReportedPhenotypeInfo", "ReviewStatus",
-    "SubmittedGeneSymbol", "GeneSymbol", "vcf_id"
-  )))
+  dplyr::select(any_of(c("VariationID", "ClinicalSignificance", "ClinicalSignificance",
+                         "LastEvaluated", "Description", "SubmittedPhenotypeInfo",
+                         "ReportedPhenotypeInfo", "ReviewStatus",
+                         "SubmittedGeneSymbol", "GeneSymbol", "vcf_id")))
 
 ## filter only those variants that need consensus call and find  call in submission table
 entries_for_cc <- filter(clinvar_anno_vcf_df, Stars == "1NR", final_call != "Benign", final_call != "Pathogenic", final_call != "Likely_benign", final_call != "Likely_pathogenic", final_call != "Uncertain_significance")

--- a/AutoGVP/01-annotate_variants_custom_input.R
+++ b/AutoGVP/01-annotate_variants_custom_input.R
@@ -265,6 +265,8 @@ submission_final_df <- variants_no_conflicts %>%
     ClinicalSignificance = ClinicalSignificance.x,
     ReviewStatus = ReviewStatus.y
   ) %>%
+  dplyr::filter(!is.na(vcf_id)) %>%
+  distinct(vcf_id, .keep_all = T) %>%
   dplyr::select(any_of(c(
     "VariationID", "ClinicalSignificance", "ClinicalSignificance",
     "LastEvaluated", "Description", "SubmittedPhenotypeInfo",

--- a/AutoGVP/01-annotate_variants_custom_input.R
+++ b/AutoGVP/01-annotate_variants_custom_input.R
@@ -285,7 +285,7 @@ variants_conflicts_latest <- submission_merged_df %>%
 
 # create final df and take ClinSig calls from submission summary
 submission_final_df <- variants_no_conflicts %>%
-  bind_rows(variants_no_conflict_expert, variants_conflicts_phenoInfo, variants_conflicts_latest) %>%
+  bind_rows(variants_no_conflict_expert, variants_consensus_call, variants_conflicts_phenoInfo, variants_conflicts_latest) %>%
   dplyr::mutate(
     ClinicalSignificance = ClinicalSignificance.x,
     ReviewStatus = ReviewStatus.y

--- a/AutoGVP/01-annotate_variants_custom_input.R
+++ b/AutoGVP/01-annotate_variants_custom_input.R
@@ -285,7 +285,7 @@ variants_conflicts_latest <- submission_merged_df %>%
 
 # create final df and take ClinSig calls from submission summary
 submission_final_df <- variants_no_conflicts %>%
-  bind_rows(variants_no_conflict_expert, variants_conflicts_phenoInfo, variants_conflicts_latest) %>%
+  bind_rows(variants_no_conflict_expert, variants_consensus_call, variants_conflicts_phenoInfo, variants_conflicts_latest) %>%
   dplyr::mutate(ClinicalSignificance = ClinicalSignificance.x,
                 ReviewStatus = ReviewStatus.y) %>%
   distinct(vcf_id, .keep_all = T) %>%

--- a/AutoGVP/01-annotate_variants_custom_input.R
+++ b/AutoGVP/01-annotate_variants_custom_input.R
@@ -285,7 +285,7 @@ variants_conflicts_latest <- submission_merged_df %>%
 
 # create final df and take ClinSig calls from submission summary
 submission_final_df <- variants_no_conflicts %>%
-  bind_rows(variants_no_conflict_expert, variants_consensus_call, variants_conflicts_phenoInfo, variants_conflicts_latest) %>%
+  bind_rows(variants_no_conflict_expert, variants_conflicts_phenoInfo, variants_conflicts_latest) %>%
   dplyr::mutate(ClinicalSignificance = ClinicalSignificance.x,
                 ReviewStatus = ReviewStatus.y) %>%
   distinct(vcf_id, .keep_all = T) %>%

--- a/AutoGVP/01-annotate_variants_custom_input.R
+++ b/AutoGVP/01-annotate_variants_custom_input.R
@@ -233,8 +233,8 @@ submission_merged_df <- submission_summary_df %>%
 # Identify VariationIDs with no ClinSig conflicts between variant and submission summary at date last evaluated
 variants_no_conflicts <- submission_merged_df %>%
   group_by(VariationID) %>%
-  dplyr::arrange(mdy(LastEvaluated)) %>%
-  dplyr::slice_tail(n = 1) %>%
+  dplyr::arrange(desc(mdy(LastEvaluated))) %>%
+  dplyr::slice_head(n = 1) %>%
   ungroup() %>%
   filter(ClinicalSignificance.x == ClinicalSignificance.y | is.na(ClinicalSignificance.y) | (grepl("Pathogenic|Likely pathogenic", ClinicalSignificance.x) & grepl("Pathogenic|Likely pathogenic", ClinicalSignificance.y)) | (grepl("Benign|Likely benign", ClinicalSignificance.x) & grepl("Benign|Likely benign", ClinicalSignificance.y)) | (grepl("Uncertain significance", ClinicalSignificance.x) & grepl("Uncertain significance", ClinicalSignificance.y)))
 
@@ -244,8 +244,8 @@ variants_conflicts_phenoInfo <- submission_merged_df %>%
   dplyr::filter(ClinicalSignificance.y != ClinicalSignificance.x) %>%
   dplyr::filter(grepl("Pathogenic|Likely pathogenic", ClinicalSignificance.x) & (!is.na(SubmittedPhenotypeInfo) | !is.na(ReportedPhenotypeInfo))) %>%
   group_by(VariationID) %>%
-  dplyr::arrange(mdy(LastEvaluated)) %>%
-  dplyr::slice_tail(n = 1) %>%
+  dplyr::arrange(desc(mdy(LastEvaluated))) %>%
+  dplyr::slice_head(n = 1) %>%
   ungroup()
 
 # Identify VariationIDs with conflicting ClinSigs, and retain call at last data evaluated
@@ -253,8 +253,8 @@ variants_conflicts_latest <- submission_merged_df %>%
   dplyr::filter(!VariationID %in% c(variants_no_conflicts$VariationID, variants_conflicts_phenoInfo$VariationID)) %>%
   dplyr::filter(ClinicalSignificance.y != ClinicalSignificance.x) %>%
   group_by(VariationID) %>%
-  dplyr::arrange(mdy(LastEvaluated)) %>%
-  dplyr::slice_tail(n = 1) %>%
+  dplyr::arrange(desc(mdy(LastEvaluated))) %>%
+  dplyr::slice_head(n = 1) %>%
   ungroup()
 
 # create final df and take ClinSig calls from submission summary


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

### Purpose/implementation Section

#### What feature is being added or bug is being addressed?

This PR modifies both `01-annotate_variants_CAVATICA_input.R` and `annotate_variants_custom_input.R` to retain a single call per variant from clinVar's `submission_summary.txt` file in a manner that matches AutoGVP's workflow. 

#### What was your approach?

Following joining of `variant_summary_df` and `submission_summary_df`, a single call was retained per variant using the following logic: 

1. If `ClinicalSignificance` columns between dfs matched at the last evaluated date, these rows were saved to df `variants_no_conflicts`
2. If `ClinicalSignificance` columns differed between dfs, and `submission_summary_df` had a P-LP call for a variant that also had associated PhenotypeInfo, these rows were saved to "variants_conflicts_phenoInfo`
3. If `ClinicalSignificance` columns differed between dfs, the rows with the last evaluated date were retained for each variant and saved to `variants_conflicts_latest`
4. `submission_final_df` was generating by binding rows of `variants_no_conflicts`, `variants_conflicts_phenoInfo`, and `variants_conflicts_latest`

#### What GitHub issue does your pull request address?

#95

### Directions for reviewers. Tell potential reviewers what kind of feedback you are soliciting.


#### Which areas should receive a particularly close look?

Please review new code logic to ensure appropriate variant calls are being retained

#### Is there anything that you want to discuss further?

No


