### PR TITLE
Modify address_ambiguous_calls() function to exclude likely pathogenic clinvar calls

### DIFF
--- a/AutoGVP/01-annotate_variants_CAVATICA_input.R
+++ b/AutoGVP/01-annotate_variants_CAVATICA_input.R
@@ -330,69 +330,28 @@ combined_tab_with_vcf_intervar <- autopvs1_results %>%
                            ((evidencePS >= 1) |
                               (evidencePM >= 2) |
                               (evidencePM == 1 & evidencePP == 1) |
-                              (evidencePP >= 2)) &
-                           ((evidenceBA1) == 1 |
-                              (evidenceBS >= 2) |
-                              (evidenceBP >= 2) |
-                              (evidenceBS >= 1 & evidenceBP >= 1) |
-                              (evidenceBA1 == 1 & (evidenceBS >= 1 | evidenceBP >= 1)))), "Uncertain_significance",
-                        ifelse(((evidencePS >= 2) &
-                                  ((evidenceBA1) == 1 |
-                                     (evidenceBS >= 2) |
-                                     (evidenceBP >= 2) |
-                                     (evidenceBS >= 1 & evidenceBP >= 1) |
-                                     (evidenceBA1 == 1 & (evidenceBS >= 1 | evidenceBP >= 1)))), "Uncertain_significance",
-                               ifelse(((evidencePS == 1 &
-                                          (evidencePM >= 3 |
-                                             (evidencePM == 2 & evidencePP >= 2) |
-                                             (evidencePM == 1 & evidencePP >= 4))) &
-                                         ((evidenceBA1) == 1 |
-                                            (evidenceBS >= 2) |
-                                            (evidenceBP >= 2) |
-                                            (evidenceBS >= 1 & evidenceBP >= 1) |
-                                            (evidenceBA1 == 1 & (evidenceBS >= 1 | evidenceBP >= 1)))), "Uncertain_significance",
-                                      ifelse((((evidencePVS1 == 1 & evidencePM == 1) |
-                                                 (evidencePS == 1 & evidencePM >= 1) |
-                                                 (evidencePS == 1 & evidencePP >= 2) |
-                                                 (evidencePM >= 3) |
-                                                 (evidencePM == 2 & evidencePP >= 2) |
-                                                 (evidencePM == 1 & evidencePP >= 4)) &
-                                                ((evidenceBA1) == 1 |
-                                                   (evidenceBS >= 2) |
-                                                   (evidenceBP >= 2) |
-                                                   (evidenceBS >= 1 & evidenceBP >= 1) |
-                                                   (evidenceBA1 == 1 & (evidenceBS >= 1 | evidenceBP >= 1)))), "Uncertain_significance",
-                                             ifelse((evidencePVS1 == 1 &
-                                                       ((evidencePS >= 1) |
-                                                          (evidencePM >= 2) |
-                                                          (evidencePM == 1 & evidencePP == 1) |
-                                                          (evidencePP >= 2))), "Pathogenic",
-                                                    ifelse((evidencePS >= 2), "Pathogenic",
-                                                           ifelse((evidencePS == 1 &
-                                                                     (evidencePM >= 3 |
-                                                                        (evidencePM == 2 & evidencePP >= 2) |
-                                                                        (evidencePM == 1 & evidencePP >= 4))), "Pathogenic",
-                                                                  ifelse((evidencePVS1 == 1 & evidencePM == 1) |
-                                                                           (evidencePS == 1 & evidencePM >= 1) |
-                                                                           (evidencePS == 1 & evidencePP >= 2) |
-                                                                           (evidencePM >= 3) |
-                                                                           (evidencePM == 2 & evidencePP >= 2) |
-                                                                           (evidencePM == 1 & evidencePP >= 4), "Likely_pathogenic",
-                                                                         ifelse((evidenceBA1 == 1) |
-                                                                                  (evidenceBS >= 2), "Benign",
-                                                                                ifelse((evidenceBS == 1 & evidenceBP == 1) |
-                                                                                         (evidenceBP >= 2), "Likely_benign", "Uncertain_significance")
-                                                                         )
-                                                                  )
-                                                           )
-                                                    )
+                              (evidencePP >= 2))), "Pathogenic",
+                        ifelse((evidencePS >= 2), "Pathogenic",
+                               ifelse((evidencePS == 1 &
+                                         (evidencePM >= 3 |
+                                            (evidencePM == 2 & evidencePP >= 2) |
+                                            (evidencePM == 1 & evidencePP >= 4))), "Pathogenic",
+                                      ifelse((evidencePVS1 == 1 & evidencePM == 1) |
+                                               (evidencePS == 1 & evidencePM >= 1) |
+                                               (evidencePS == 1 & evidencePP >= 2) |
+                                               (evidencePM >= 3) |
+                                               (evidencePM == 2 & evidencePP >= 2) |
+                                               (evidencePM == 1 & evidencePP >= 4), "Likely_pathogenic",
+                                             ifelse((evidenceBA1 == 1) |
+                                                      (evidenceBS >= 2), "Benign",
+                                                    ifelse((evidenceBS == 1 & evidenceBP == 1) |
+                                                             (evidenceBP >= 2), "Likely_benign", "Uncertain_significance")
                                              )
                                       )
                                )
                         )
     )
   )
-
 
 
 ## merge tables together (clinvar and intervar) and write to file

--- a/AutoGVP/01-annotate_variants_CAVATICA_input.R
+++ b/AutoGVP/01-annotate_variants_CAVATICA_input.R
@@ -120,14 +120,14 @@ address_conflicting_intrep <- function(clinvar_anno_vcf_df) { ## if conflicting 
 }
 
 address_ambiguous_calls <- function(results_tab_abridged) { ## address ambiguous calls (non L/LB/P/LP/VUS) by taking the InterVar final call
-  
+
   results_tab_abridged <- results_tab_abridged %>%
     dplyr::mutate(new_call = case_when(
       is.na(final_call) | (final_call != "Pathogenic" &
-                             final_call != "Likely_benign" & final_call != "Likely_pathogenic" &
-                             final_call != "Uncertain_significance" & final_call != "Benign" &
-                             final_call != "Uncertain significance" & final_call != "Likely benign" &
-                             final_call != "Likely pathogenic") ~ str_match(Intervar_evidence, "InterVar\\:\\s(\\w+\\s\\w+)*")[, 2],
+        final_call != "Likely_benign" & final_call != "Likely_pathogenic" &
+        final_call != "Uncertain_significance" & final_call != "Benign" &
+        final_call != "Uncertain significance" & final_call != "Likely benign" &
+        final_call != "Likely pathogenic") ~ str_match(Intervar_evidence, "InterVar\\:\\s(\\w+\\s\\w+)*")[, 2],
       TRUE ~ NA_character_
     )) %>%
     dplyr::mutate(final_call = case_when(
@@ -327,29 +327,29 @@ combined_tab_with_vcf_intervar <- autopvs1_results %>%
 
     ## adjust variables based on given rules described in README
     final_call = ifelse((evidencePVS1 == 1 &
-                           ((evidencePS >= 1) |
-                              (evidencePM >= 2) |
-                              (evidencePM == 1 & evidencePP == 1) |
-                              (evidencePP >= 2))), "Pathogenic",
-                        ifelse((evidencePS >= 2), "Pathogenic",
-                               ifelse((evidencePS == 1 &
-                                         (evidencePM >= 3 |
-                                            (evidencePM == 2 & evidencePP >= 2) |
-                                            (evidencePM == 1 & evidencePP >= 4))), "Pathogenic",
-                                      ifelse((evidencePVS1 == 1 & evidencePM == 1) |
-                                               (evidencePS == 1 & evidencePM >= 1) |
-                                               (evidencePS == 1 & evidencePP >= 2) |
-                                               (evidencePM >= 3) |
-                                               (evidencePM == 2 & evidencePP >= 2) |
-                                               (evidencePM == 1 & evidencePP >= 4), "Likely_pathogenic",
-                                             ifelse((evidenceBA1 == 1) |
-                                                      (evidenceBS >= 2), "Benign",
-                                                    ifelse((evidenceBS == 1 & evidenceBP == 1) |
-                                                             (evidenceBP >= 2), "Likely_benign", "Uncertain_significance")
-                                             )
-                                      )
-                               )
-                        )
+      ((evidencePS >= 1) |
+        (evidencePM >= 2) |
+        (evidencePM == 1 & evidencePP == 1) |
+        (evidencePP >= 2))), "Pathogenic",
+    ifelse((evidencePS >= 2), "Pathogenic",
+      ifelse((evidencePS == 1 &
+        (evidencePM >= 3 |
+          (evidencePM == 2 & evidencePP >= 2) |
+          (evidencePM == 1 & evidencePP >= 4))), "Pathogenic",
+      ifelse((evidencePVS1 == 1 & evidencePM == 1) |
+        (evidencePS == 1 & evidencePM >= 1) |
+        (evidencePS == 1 & evidencePP >= 2) |
+        (evidencePM >= 3) |
+        (evidencePM == 2 & evidencePP >= 2) |
+        (evidencePM == 1 & evidencePP >= 4), "Likely_pathogenic",
+      ifelse((evidenceBA1 == 1) |
+        (evidenceBS >= 2), "Benign",
+      ifelse((evidenceBS == 1 & evidenceBP == 1) |
+        (evidenceBP >= 2), "Likely_benign", "Uncertain_significance")
+      )
+      )
+      )
+    )
     )
   )
 

--- a/AutoGVP/01-annotate_variants_custom_input.R
+++ b/AutoGVP/01-annotate_variants_custom_input.R
@@ -98,9 +98,10 @@ address_ambiguous_calls <- function(results_tab_abridged) { ## address ambiguous
   results_tab_abridged <- results_tab_abridged %>%
     dplyr::mutate(new_call = case_when(
       is.na(final_call) | (final_call != "Pathogenic" &
-        final_call != "Likely_benign" & final_call != "Likely_pathogenic" &
-        final_call != "Uncertain_significance" & final_call != "Benign" &
-        final_call != "Uncertain significance" & final_call != "Likely benign") ~ str_match(Intervar_evidence, "InterVar\\:\\s(\\w+\\s\\w+)*")[, 2],
+                             final_call != "Likely_benign" & final_call != "Likely_pathogenic" &
+                             final_call != "Uncertain_significance" & final_call != "Benign" &
+                             final_call != "Uncertain significance" & final_call != "Likely benign" &
+                             final_call != "Likely pathogenic") ~ str_match(Intervar_evidence, "InterVar\\:\\s(\\w+\\s\\w+)*")[, 2],
       TRUE ~ NA_character_
     )) %>%
     dplyr::mutate(final_call = case_when(

--- a/AutoGVP/01-annotate_variants_custom_input.R
+++ b/AutoGVP/01-annotate_variants_custom_input.R
@@ -98,10 +98,10 @@ address_ambiguous_calls <- function(results_tab_abridged) { ## address ambiguous
   results_tab_abridged <- results_tab_abridged %>%
     dplyr::mutate(new_call = case_when(
       is.na(final_call) | (final_call != "Pathogenic" &
-                             final_call != "Likely_benign" & final_call != "Likely_pathogenic" &
-                             final_call != "Uncertain_significance" & final_call != "Benign" &
-                             final_call != "Uncertain significance" & final_call != "Likely benign" &
-                             final_call != "Likely pathogenic") ~ str_match(Intervar_evidence, "InterVar\\:\\s(\\w+\\s\\w+)*")[, 2],
+        final_call != "Likely_benign" & final_call != "Likely_pathogenic" &
+        final_call != "Uncertain_significance" & final_call != "Benign" &
+        final_call != "Uncertain significance" & final_call != "Likely benign" &
+        final_call != "Likely pathogenic") ~ str_match(Intervar_evidence, "InterVar\\:\\s(\\w+\\s\\w+)*")[, 2],
       TRUE ~ NA_character_
     )) %>%
     dplyr::mutate(final_call = case_when(


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

### Purpose/implementation Section

#### What feature is being added or bug is being addressed?

Closes #122 . 


#### What was your approach?

I've modified the `address_ambiguous_calls()` function to exclude variants with `final_call == "Likely pathogenic"`, as this was causing all variants that met this criteria to take the Intervar call for final call. 

#### What GitHub issue does your pull request address?

#122 

### Directions for reviewers. Tell potential reviewers what kind of feedback you are soliciting.


#### Which areas should receive a particularly close look?

Please check new logic in `address_ambiguous_calls()` function

#### Is there anything that you want to discuss further?

No


