### PR TITLE
Fix filter vcf script so first filtering criterion is applied

### DIFF
--- a/AutoGVP/01-annotate_variants_custom_input.R
+++ b/AutoGVP/01-annotate_variants_custom_input.R
@@ -256,7 +256,7 @@ if (tally(multianno_df) != tally(clinvar_anno_intervar_vcf_df)) {
 ## combine the intervar and multianno tables by the appropriate vcf id
 clinvar_anno_intervar_vcf_df <-
   dplyr::mutate(multianno_df, clinvar_anno_intervar_vcf_df) %>%
-  dplyr::filter(vcf_id %in% vcf_df$vcf_id) #%>%
+  dplyr::filter(vcf_id %in% vcf_df$vcf_id) # %>%
 
 ## populate consensus call variants with invervar info
 entries_for_cc_in_submission_w_intervar <- inner_join(clinvar_anno_intervar_vcf_df, entries_for_cc_in_submission, by = "vcf_id") %>%
@@ -347,13 +347,13 @@ combined_tab_with_vcf_intervar <- autopvs1_results %>%
         (evidenceBP >= 2) |
         (evidenceBS >= 1 & evidenceBP >= 1) |
         (evidenceBA1 == 1 & (evidenceBS >= 1 | evidenceBP >= 1)))), "Uncertain_significance",
-    ifelse(((evidencePVS1 == 1) &(evidencePS >= 2) &
+    ifelse(((evidencePVS1 == 1) & (evidencePS >= 2) &
       ((evidenceBA1) == 1 |
         (evidenceBS >= 2) |
         (evidenceBP >= 2) |
         (evidenceBS >= 1 & evidenceBP >= 1) |
         (evidenceBA1 == 1 & (evidenceBS >= 1 | evidenceBP >= 1)))), "Uncertain_significance",
-    ifelse(((evidencePVS1 == 1) &(evidencePS == 1 &
+    ifelse(((evidencePVS1 == 1) & (evidencePS == 1 &
       (evidencePM >= 3 |
         (evidencePM == 2 & evidencePP >= 2) |
         (evidencePM == 1 & evidencePP >= 4))) &
@@ -362,7 +362,7 @@ combined_tab_with_vcf_intervar <- autopvs1_results %>%
         (evidenceBP >= 2) |
         (evidenceBS >= 1 & evidenceBP >= 1) |
         (evidenceBA1 == 1 & (evidenceBS >= 1 | evidenceBP >= 1)))), "Uncertain_significance",
-    ifelse((((evidencePVS1 == 1) &(evidencePVS1 == 1 & evidencePM == 1) |
+    ifelse((((evidencePVS1 == 1) & (evidencePVS1 == 1 & evidencePM == 1) |
       (evidencePS == 1 & evidencePM >= 1) |
       (evidencePS == 1 & evidencePP >= 2) |
       (evidencePM >= 3) |
@@ -373,12 +373,12 @@ combined_tab_with_vcf_intervar <- autopvs1_results %>%
         (evidenceBP >= 2) |
         (evidenceBS >= 1 & evidenceBP >= 1) |
         (evidenceBA1 == 1 & (evidenceBS >= 1 | evidenceBP >= 1)))), "Uncertain_significance",
-    ifelse((evidencePVS1 == 1) &(evidencePVS1 == 1 &
+    ifelse((evidencePVS1 == 1) & (evidencePVS1 == 1 &
       ((evidencePS >= 1) |
         (evidencePM >= 2) |
         (evidencePM == 1 & evidencePP == 1) |
         (evidencePP >= 2))), "Pathogenic",
-    ifelse((evidencePVS1 == 1) &(evidencePS >= 2), "Pathogenic",
+    ifelse((evidencePVS1 == 1) & (evidencePS >= 2), "Pathogenic",
       ifelse((evidencePVS1 == 0) & (evidencePS == 1 &
         (evidencePM >= 3 |
           (evidencePM == 2 & evidencePP >= 2) |
@@ -443,11 +443,11 @@ master_tab <- full_join(master_tab, entries_for_cc_in_submission, by = "vcf_id")
   full_join(entries_for_cc_in_submission_w_intervar[c("vcf_id", "Intervar_evidence")], by = "vcf_id") %>%
   dplyr::mutate(
     Intervar_evidence = coalesce(Intervar_evidence.y, Intervar_evidence.x),
-    #ClinVar_ClinicalSignificance = coalesce(ClinicalSignificance.x, ClinicalSignificance.y)
+    # ClinVar_ClinicalSignificance = coalesce(ClinicalSignificance.x, ClinicalSignificance.y)
   ) %>%
   dplyr::select(
     -final_call.x, -final_call.y,
-    -Intervar_evidence.x, -Intervar_evidence.y #,
+    -Intervar_evidence.x, -Intervar_evidence.y # ,
     #-ClinicalSignificance.x, -ClinicalSignificance.y
   )
 

--- a/AutoGVP/filter_vcf.sh
+++ b/AutoGVP/filter_vcf.sh
@@ -17,7 +17,7 @@ echo "vcf file: $vcf_file ";
 cmd="bcftools view -f 'PASS,.' $vcf_file"
 
 ## loop through args for other user-defined filters
-for i in "${exp_args[@]:4}"; do
+for i in "${exp_args[@]:3}"; do
   #echo filtering for... $i
   cmd+=" | bcftools filter -i '$i'"
 #  cmd+=" $vcf_file "


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

### Purpose/implementation Section

#### What feature is being added or bug is being addressed?

closes #127. There was a minor bug where the first filtering criterion was being skipped in `filter_vcf.sh`, due to the script searching for criterion starting in the 4th argument rather than the 3rd. 

#### What was your approach?

Fixed loop so filtering criterion are searched for starting with 3rd argument. 

#### What GitHub issue does your pull request address?

#127 

### Directions for reviewers. Tell potential reviewers what kind of feedback you are soliciting.


#### Which areas should receive a particularly close look?

Run test pbta sample using following command and confirm that filtering command includes all three criteria: 

```
bash run_autogvp.sh --workflow="cavatica" \
--vcf=input/test_pbta.single.vqsr.filtered.vep_105.vcf \
--filter_criteria='INFO/AF>=0.2 INFO/DP>=15 (gnomad_3_1_1_AF_non_cancer<0.01|gnomad_3_1_1_AF_non_cancer=".")' \
--intervar=input/test_pbta.hg38_multianno.txt.intervar \
--multianno=input/test_pbta.hg38_multianno.txt \
--autopvs1=input/test_pbta.autopvs1.tsv \
--outdir=../results \
--out="test_pbta"
```

#### Is there anything that you want to discuss further?

No

