### PR TITLE
update clinvar star assignment code

### DIFF
--- a/AutoGVP/01-annotate_variants_CAVATICA_input.R
+++ b/AutoGVP/01-annotate_variants_CAVATICA_input.R
@@ -183,7 +183,7 @@ additional_intervar_cases <- filter(clinvar_anno_vcf_df, final_call != "Benign",
 
 
 ## filter only those variant entries that need an InterVar run (No Star) and add the additional intervar cases from above
-entries_for_intervar <- filter(clinvar_anno_vcf_df, Stars == "0", na.rm = TRUE) %>%
+entries_for_intervar <- filter(clinvar_anno_vcf_df, Stars == "0" | is.na(Stars), na.rm = TRUE) %>%
   bind_rows((additional_intervar_cases)) %>%
   distinct()
 

--- a/AutoGVP/01-annotate_variants_CAVATICA_input.R
+++ b/AutoGVP/01-annotate_variants_CAVATICA_input.R
@@ -91,7 +91,7 @@ address_conflicting_intrep <- function(clinvar_anno_vcf_df) { ## if conflicting 
   for (i in 1:nrow(clinvar_anno_vcf_df))
   {
     entry <- clinvar_anno_vcf_df[i, ]
-    if (entry$Stars != "1NR") {
+    if ((entry$Stars != "1NR" & !is.na(entry$Stars)) | is.na(entry$Stars)) {
       next
     }
 
@@ -139,27 +139,28 @@ address_ambiguous_calls <- function(results_tab_abridged) { ## address ambiguous
   return(results_tab_abridged)
 }
 
-## retrieve and store clinVar input file into table data.table::fread()
-vcf_input <- vroom(input_clinVar_file, comment = "#", delim = "\t", col_names = c("CHROM", "START", "ID", "REF", "ALT", "QUAL", "FILTER", "INFO", "FORMAT", "Sample"), show_col_types = TRUE)
+## retrieve and store clinVar input file into table
+clinvar_anno_vcf_df <- vroom(input_clinVar_file, comment = "#", delim = "\t", col_names = c("CHROM", "START", "ID", "REF", "ALT", "QUAL", "FILTER", "INFO", "FORMAT", "Sample"), show_col_types = TRUE)
 
 ## add column "vcf_id" to clinVar results in order to cross-reference with intervar and autopvs1 table
-clinvar_anno_vcf_df <- vcf_input %>%
+clinvar_anno_vcf_df <- clinvar_anno_vcf_df %>%
   dplyr::mutate(
     vcf_id = str_remove_all(paste(CHROM, "-", START, "-", REF, "-", ALT), " "),
-    vcf_id = str_replace_all(vcf_id, "chr", ""),
+    vcf_id = str_replace(vcf_id, "chr", ""),
     # add star annotations to clinVar results table based on filters // ## default version
-    Stars = ifelse(grepl("CLNREVSTAT\\=criteria_provided,_single_submitter", INFO), "1",
-      ifelse(grepl("CLNREVSTAT\\=criteria_provided,_multiple_submitters", INFO), "2",
-        ifelse(grepl("CLNREVSTAT\\=reviewed_by_expert_panel", INFO), "3",
-          ifelse(grepl("CLNREVSTAT\\=practice_guideline", INFO), "4",
-            ifelse(grepl("CLNREVSTAT\\=criteria_provided,_conflicting_interpretations", INFO), "1NR", "0")
-          )
-        )
-      )
+    Stars = case_when(
+      str_detect(INFO, "CLNREVSTAT\\=criteria_provided,_single_submitter") ~ "1",
+      str_detect(INFO, "CLNREVSTAT\\=criteria_provided,_multiple_submitters") ~ "2",
+      str_detect(INFO, "CLNREVSTAT\\=reviewed_by_expert_panel") ~ "3",
+      str_detect(INFO, "CLNREVSTAT\\=practice_guideline") ~ "4",
+      str_detect(INFO, "CLNREVSTAT\\=criteria_provided,_conflicting_interpretations") ~ "1NR",
+      str_detect(INFO, "no_assertion") ~ "0",
+      TRUE ~ NA_character_
     ),
     ## extract the calls and put in own column
     final_call = str_match(INFO, "CLNSIG\\=(\\w+)([\\|\\/]\\w+)*\\;")[, 2]
   )
+
 
 ## if conflicting intrep. take the call with most calls in CLNSIGCONF field
 clinvar_anno_vcf_df <- address_conflicting_intrep(clinvar_anno_vcf_df)

--- a/AutoGVP/01-annotate_variants_custom_input.R
+++ b/AutoGVP/01-annotate_variants_custom_input.R
@@ -205,7 +205,7 @@ clinvar_anti_join_vcf_df <- clinvar_anti_join_vcf_df %>%
   )
 
 ## filter only those variant entries that need an InterVar run (No Star) and add the additional intervar cases from above
-entries_for_intervar <- filter(clinvar_anno_vcf_df, Stars == "0", na.rm = TRUE) %>%
+entries_for_intervar <- filter(clinvar_anno_vcf_df, Stars == "0" | is.na(Stars), na.rm = TRUE) %>%
   bind_rows((additional_intervar_cases)) %>%
   bind_rows(clinvar_anti_join_vcf_df) %>%
   distinct()

--- a/AutoGVP/01-annotate_variants_custom_input.R
+++ b/AutoGVP/01-annotate_variants_custom_input.R
@@ -116,7 +116,7 @@ address_ambiguous_calls <- function(results_tab_abridged) { ## address ambiguous
 address_conflicting_intrep <- function(clinvar_anno_vcf_df) { ## if conflicting intrep. take the call with most calls in CLNSIGCONF field
   for (i in 1:nrow(clinvar_anno_vcf_df)) {
     entry <- clinvar_anno_vcf_df[i, ]
-    if (entry$Stars != "1NR") {
+    if ((entry$Stars != "1NR" & !is.na(entry$Stars)) | is.na(entry$Stars)) {
       next
     }
 
@@ -159,14 +159,14 @@ clinvar_anno_vcf_df <- vroom(input_clinVar_file, comment = "#", delim = "\t", co
   dplyr::mutate(
     vcf_id = str_replace_all(vcf_id, "chr", ""),
     # add star annotations to clinVar results table based on filters // ## default version
-    Stars = ifelse(grepl("CLNREVSTAT\\=criteria_provided,_single_submitter", INFO), "1",
-      ifelse(grepl("CLNREVSTAT\\=criteria_provided,_multiple_submitters", INFO), "2",
-        ifelse(grepl("CLNREVSTAT\\=reviewed_by_expert_panel", INFO), "3",
-          ifelse(grepl("CLNREVSTAT\\=practice_guideline", INFO), "4",
-            ifelse(grepl("CLNREVSTAT\\=criteria_provided,_conflicting_interpretations", INFO), "1NR", "0")
-          )
-        )
-      )
+    Stars = case_when(
+      str_detect(INFO, "CLNREVSTAT\\=criteria_provided,_single_submitter") ~ "1",
+      str_detect(INFO, "CLNREVSTAT\\=criteria_provided,_multiple_submitters") ~ "2",
+      str_detect(INFO, "CLNREVSTAT\\=reviewed_by_expert_panel") ~ "3",
+      str_detect(INFO, "CLNREVSTAT\\=practice_guideline") ~ "4",
+      str_detect(INFO, "CLNREVSTAT\\=criteria_provided,_conflicting_interpretations") ~ "1NR",
+      str_detect(INFO, "no_assertion") ~ "0",
+      TRUE ~ NA_character_
     ),
     ## extract the calls and put in own column
     final_call = str_match(INFO, "CLNSIG\\=(\\w+)([\\|\\/]\\w+)*\\;")[, 2]


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

### Purpose/implementation Section

#### What feature is being added or bug is being addressed?

Closes #132 and #133. This PR modifies assignment of ClinVar stars to variants in vcf file by using `str_detect`, and modifies logic so variants that are not in ClinVar database are `clinvar_stars == 0`. 

#### What was your approach?

See above. 

#### What GitHub issue does your pull request address?

#132 and #133

### Directions for reviewers. Tell potential reviewers what kind of feedback you are soliciting.


#### Which areas should receive a particularly close look?

Please review updated code logic, and run test_pbta and custom test scripts through autogvp shell script. Check that all variants with `is.na(clivnar_clinsig)` also have `clinvar_stars` set to `NA`.  

```
bash run_autogvp.sh --workflow="cavatica" \
--vcf=input/test_pbta.single.vqsr.filtered.vep_105.vcf \
--filter_criteria='INFO/AF>=0.2 INFO/DP>=15 (gnomad_3_1_1_AF_non_cancer<0.01|gnomad_3_1_1_AF_non_cancer=".")' \
--intervar=input/test_pbta.hg38_multianno.txt.intervar \
--multianno=input/test_pbta.hg38_multianno.txt \
--autopvs1=input/test_pbta.autopvs1.tsv \
--outdir=../results \
--out="test_pbta"
```

```
bash run_autogvp.sh --workflow="custom" \
--vcf=input/test_VEP.vcf \
--clinvar=input/clinvar.vcf.gz \
--intervar=input/test_VEP.hg38_multianno.txt.intervar \
--multianno=input/test_VEP.vcf.hg38_multianno.txt \
--autopvs1=input/test_autopvs1.txt \
--outdir=../results \
--out="test_custom"
```

#### Is there anything that you want to discuss further?

No

#### Documentation Checklist

<!-- Please review and specify if it isn't applicable -->

- [X] The function has examples to showcase the usage 

