### PR TITLE
update address_conflicting_interp()

### DIFF
--- a/AutoGVP/01-annotate_variants_custom_input.R
+++ b/AutoGVP/01-annotate_variants_custom_input.R
@@ -113,35 +113,42 @@ address_ambiguous_calls <- function(results_tab_abridged) { ## address ambiguous
   return(results_tab_abridged)
 }
 
-address_conflicting_intrep <- function(clinvar_anno_vcf_df) { ## if conflicting intrep. take the call with most calls in CLNSIGCONF field
-  for (i in 1:nrow(clinvar_anno_vcf_df)) {
-    entry <- clinvar_anno_vcf_df[i, ]
-    if ((entry$Stars != "1NR" & !is.na(entry$Stars)) | is.na(entry$Stars)) {
-      next
-    }
-
-    conf_section <- str_match(entry$INFO, "CLNSIGCONF\\=.+\\;CLNVC") ## part to parse and count calls
+address_conflicting_interp <- function(clinvar_anno_vcf_df) { ## if conflicting intrep. take the call with most calls in CLNSIGCONF field
+  
+  clinvar_nr <- clinvar_anno_vcf_df %>%
+    dplyr::filter(Stars == "1NR" & !is.na(Stars))
+  
+  for (i in 1:nrow(clinvar_nr)){
+    
+    conf_section <- str_match(clinvar_nr$INFO[i], "CLNSIGCONF\\=.+\\;CLNVC") ## part to parse and count calls
     call_names <- c("Pathogenic", "Likely_pathogenic", "Benign", "Likely_benign", "Uncertain_significance")
-
+    
     P <- (str_match(conf_section, "Pathogenic\\((\\d+)\\)")[, 2])
     LP <- (str_match(conf_section, "Likely_pathogenic\\((\\d+)\\)")[, 2])
     B <- (str_match(conf_section, "Benign\\((\\d+)\\)")[, 2])
     LB <- (str_match(conf_section, "Likely_benign\\((\\d+)\\)")[, 2])
     U <- (str_match(conf_section, "Uncertain_significance\\((\\d+)\\)")[, 2])
-
+    
     ## make vector out of possible calls to get max
     calls <- c(P, LP, B, LB, U)
-
+    
     if (length(which(calls == max(calls, na.rm = TRUE))) > 1) {
       next
     }
-
+    
     highest_ind <- which.max(calls)
     consensus_call <- call_names[highest_ind]
-
-    clinvar_anno_vcf_df[i, ]$final_call <- consensus_call
+    
+    clinvar_nr[i, ]$final_call <- consensus_call
+    
   }
-  return(clinvar_anno_vcf_df)
+  
+  clinvar_anno_vcf_df <- clinvar_anno_vcf_df %>%
+    left_join(clinvar_nr[,c("vcf_id", "final_call")], by = "vcf_id", suffix = c(".orig", ".resolved")) %>%
+    dplyr::mutate(final_call = coalesce(final_call.resolved, final_call.orig)) %>%
+    dplyr::select(-final_call.resolved, -final_call.orig) %>%
+    
+    return(clinvar_anno_vcf_df)
 }
 
 ## make vcf dataframe and add vcf_if column
@@ -172,7 +179,7 @@ clinvar_anno_vcf_df <- vroom(input_clinVar_file, comment = "#", delim = "\t", co
     final_call = str_match(INFO, "CLNSIG\\=(\\w+)([\\|\\/]\\w+)*\\;")[, 2]
   )
 
-clinvar_anno_vcf_df <- address_conflicting_intrep(clinvar_anno_vcf_df)
+clinvar_anno_vcf_df <- address_conflicting_interp(clinvar_anno_vcf_df)
 
 ## store variants without clinvar info
 clinvar_anti_join_vcf_df <- anti_join(vcf_df, clinvar_anno_vcf_df, by = "vcf_id") %>%


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

### Purpose/implementation Section

#### What feature is being added or bug is being addressed?

Closes #130. This PR modifies the `address_conflicting_interp()` to only loop through variants with `Stars == "1NR"`. 

#### What was your approach?

Added a line in function code to filter `clinvar_anno_vcf_df` for only variants with `Stars == "1NR"`. This will reduce time taken to run the function since not all variants will be looped through. 

#### What GitHub issue does your pull request address?

#130 

### Directions for reviewers. Tell potential reviewers what kind of feedback you are soliciting.


#### Which areas should receive a particularly close look?

Please review new code logic and run test_pbta and custom test files

```
bash run_autogvp.sh --workflow="cavatica" \
--vcf=input/test_pbta.single.vqsr.filtered.vep_105.vcf \
--filter_criteria='INFO/AF>=0.2 INFO/DP>=15 (gnomad_3_1_1_AF_non_cancer<0.01|gnomad_3_1_1_AF_non_cancer=".")' \
--intervar=input/test_pbta.hg38_multianno.txt.intervar \
--multianno=input/test_pbta.hg38_multianno.txt \
--autopvs1=input/test_pbta.autopvs1.tsv \
--outdir=../results \
--out="test_pbta"
```

```
bash run_autogvp.sh --workflow="custom" \
--vcf=input/test_VEP.vcf \
--clinvar=input/clinvar.vcf.gz \
--intervar=input/test_VEP.hg38_multianno.txt.intervar \
--multianno=input/test_VEP.vcf.hg38_multianno.txt \
--autopvs1=input/test_autopvs1.txt \
--outdir=../results \
--out="test_custom"
```


#### Is there anything that you want to discuss further?

No

#### Documentation Checklist

<!-- Please review and specify if it isn't applicable -->

- [X] The function has examples to showcase the usage 

