### PR TITLE
Filter multianno, autopvs1, intervar files before loading in R

### DIFF
--- a/AutoGVP/filter_vcf.sh
+++ b/AutoGVP/filter_vcf.sh
@@ -2,10 +2,12 @@
 
 # Define variables
 vcf_file=$1
-out_file=$2
-out_dir=$3
+multianno_file=$2
+autopvs1_file=$3
+intervar_file=$4
+out_file=$5
+out_dir=$6
 exp_args=("$@")
-
 
 # Define filtered vcf output file 
 vcf_filtered_file=${out_file}."filtered.vcf"
@@ -17,7 +19,7 @@ echo "vcf file: $vcf_file ";
 cmd="bcftools view -f 'PASS,.' $vcf_file"
 
 ## loop through args for other user-defined filters
-for i in "${exp_args[@]:3}"; do
+for i in "${exp_args[@]:6}"; do
   #echo filtering for... $i
   cmd+=" | bcftools filter -i '$i'"
 #  cmd+=" $vcf_file "
@@ -32,3 +34,33 @@ echo "cmd: " $cmd
 
 # execute command
 eval "$cmd"
+
+# extract vcf positions
+bcftools query -f "%POS\n" $out_dir/$vcf_filtered_file > $out_dir/${out_file}_vcf_filtered_positions.tsv
+echo "Chr" >> $out_dir/${out_file}_vcf_filtered_positions.tsv
+echo "vcf_id" >> $out_dir/${out_file}_vcf_filtered_positions.tsv
+
+# filter multianno file for filtered vcf positions
+echo "Filtering multianno file..."
+
+multianno_filtered_file=${out_file}_multianno_filtered.txt
+zgrep -Fw -f $out_dir/${out_file}_vcf_filtered_positions.tsv $multianno_file > $out_dir/$multianno_filtered_file
+
+# filter autopvs1 file for filtered vcf positions
+echo "Filtering autopvs1 file..."
+
+autopvs1_filtered_file=${out_file}_autopvs1_filtered.tsv
+zgrep -Fw -f $out_dir/${out_file}_vcf_filtered_positions.tsv $autopvs1_file > $out_dir/$autopvs1_filtered_file
+
+# extract multianno file positions to match with intervar file positions
+cat $out_dir/$multianno_filtered_file | awk '{print $2}' > $out_dir/${out_file}_multianno_filtered_positions.tsv
+echo "#Chr" >> $out_dir/${out_file}_multianno_filtered_positions.tsv
+
+# filter intervar file for filtered multianno positions
+echo "Filtering intervar file..."
+
+intervar_filtered_file=${out_file}_intervar_filtered.txt
+zgrep -Fw -f $out_dir/${out_file}_multianno_filtered_positions.tsv $intervar_file > $out_dir/$intervar_filtered_file
+
+# remove position files
+rm $out_dir/${out_file}_vcf_filtered_positions.tsv $out_dir/${out_file}_multianno_filtered_positions.tsv 

--- a/AutoGVP/run_autogvp.sh
+++ b/AutoGVP/run_autogvp.sh
@@ -80,8 +80,12 @@ done
 echo "Filtering VCF..."
 
 vcf_filtered_file=${out_file}."filtered.vcf"
-bash filter_vcf.sh $vcf_file $out_file $out_dir $filtering_criteria
+bash filter_vcf.sh $vcf_file $multianno_file $autopvs1_file $intervar_file $out_file $out_dir $filtering_criteria
+
 autogvp_input=$out_dir/$vcf_filtered_file
+multianno_input=$out_dir/${out_file}_multianno_filtered.txt
+autopvs1_input=$out_dir/${out_file}_autopvs1_filtered.tsv
+intervar_input=$out_dir/${out_file}_intervar_filtered.txt
 
 # Run AutoGVP 
 echo "Running AutoGVP..."
@@ -91,9 +95,9 @@ if [[ "$workflow" = "cavatica" ]];then
 
   # Run AutoGVP from Cavatica workflow
   Rscript 01-annotate_variants_CAVATICA_input.R --vcf $autogvp_input \
-  --multianno $multianno_file \
-  --intervar $intervar_file \
-  --autopvs1 $autopvs1_file \
+  --multianno $multianno_input \
+  --intervar $intervar_input \
+  --autopvs1 $autopvs1_input \
   --output $out_file \
   --variant_summary $variant_summary_file
   
@@ -104,9 +108,9 @@ if [[ "$workflow" = "cavatica" ]];then
   # Run AutoGVP from custom workflow
   Rscript 01-annotate_variants_custom_input.R --vcf $autogvp_input \
   --clinvar $clinvar_file \
-  --multianno $multianno_file \
-  --intervar $intervar_file \
-  --autopvs1 $autopvs1_file \
+  --multianno $multianno_input \
+  --intervar $intervar_input \
+  --autopvs1 $autopvs1_input \
   --output $out_file \
   --variant_summary $variant_summary_file \
   
@@ -130,4 +134,4 @@ echo "Filtering VEP annotations and creating final output..."
 Rscript 04-filter_gene_annotations.R --vcf $vcf_parsed_file --autogvp $autogvp_output --output $out_file
 
 # Remove intermediate files
-rm $autogvp_input $vcf_parsed_file $out_dir/$autogvp_output $out_dir/$out_file.filtered_csq_subfields.tsv
+rm $autogvp_input $vcf_parsed_file $out_dir/$autogvp_output $out_dir/$out_file.filtered_csq_subfields.tsv $out_dir/${out_file}_multianno_filtered.txt $out_dir/${out_file}_autopvs1_filtered.tsv $out_dir/${out_file}_intervar_filtered.txt


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

### Purpose/implementation Section

#### What feature is being added or bug is being addressed?

Closes #142. This PR adds code to filter all annotation files for those positions contained in filtered vcf. These filtered files are used as input for `01-annotate_variants_CAVATICA_input.R` and `01-annotate_variants_custom_input.R`. 

#### What was your approach?

- Updated `filter_vcf.sh` script to include code that extracts filtered vcf positions, which are subsequently used to grep filter annotation files using `zgrep()`
- Updated `run_autogvp.sh` to take filtered annotation files as input for `01-annotate_variants_CAVATICA_input.R` and `01-annotate_variants_custom_input.R`. 

#### What GitHub issue does your pull request address?

#142 

### Directions for reviewers. Tell potential reviewers what kind of feedback you are soliciting.


#### Which areas should receive a particularly close look?

Please review updated code logic and run on test pbta and test custom files to ensure output looks as expected. 

#### Is there anything that you want to discuss further?

Note that, since we are only filtering by prepping for positions in filtered vcfs in the annotation files, we are not filtering for the variants themselves per se. There are certainly some cases where rows are retained because a non-position column in the vcf file matches a position in the filtered vcf file. But, this approach is still effective in reducing overall memory usage of AutoGVP by ~40%. I am open to other suggestions on how to improve this filtering! 


