### PR TITLE
Select AutoPVS1 transcript as final variant annotation 

### DIFF
--- a/AutoGVP/01-annotate_variants_CAVATICA_input.R
+++ b/AutoGVP/01-annotate_variants_CAVATICA_input.R
@@ -270,7 +270,7 @@ clinvar_anno_intervar_vcf_df <- clinvar_anno_intervar_vcf_df %>%
 
 ## autopvs1 results
 autopvs1_results <- vroom(input_autopvs1_file, col_names = TRUE) %>%
-  dplyr::select(vcf_id, criterion) %>%
+  dplyr::select(vcf_id, Feature, criterion) %>%
   mutate(
     vcf_id = str_remove_all(vcf_id, " "),
     vcf_id = str_replace_all(vcf_id, "chr", "")
@@ -398,8 +398,9 @@ combined_tab_with_vcf_intervar <- autopvs1_results %>%
 
 ## merge tables together (clinvar and intervar) and write to file
 master_tab <- clinvar_anno_intervar_vcf_df %>%
-  full_join(combined_tab_with_vcf_intervar[, grepl("vcf_id|intervar_adjusted|evidence|InterVar:|criterion|final_call", names(combined_tab_with_vcf_intervar))], by = "vcf_id") %>%
-  left_join(variant_summary_df, by = "vcf_id")
+  full_join(combined_tab_with_vcf_intervar[, grepl("vcf_id|intervar_adjusted|evidence|InterVar:|final_call", names(combined_tab_with_vcf_intervar))], by = "vcf_id") %>%
+  left_join(variant_summary_df, by = "vcf_id") %>%
+  left_join(autopvs1_results, by = "vcf_id")
 
 
 master_tab <- master_tab %>%

--- a/AutoGVP/01-annotate_variants_custom_input.R
+++ b/AutoGVP/01-annotate_variants_custom_input.R
@@ -289,7 +289,7 @@ clinvar_anno_intervar_vcf_df <- clinvar_anno_intervar_vcf_df %>%
 
 ## autopvs1 results
 autopvs1_results <- vroom(input_autopvs1_file, col_names = TRUE) %>%
-  dplyr::select(vcf_id, criterion) %>%
+  dplyr::select(vcf_id, Feature, criterion) %>%
   mutate(
     vcf_id = str_remove_all(vcf_id, " "),
     vcf_id = str_replace_all(vcf_id, "chr", "")
@@ -414,8 +414,9 @@ combined_tab_with_vcf_intervar <- autopvs1_results %>%
 
 ## merge tables together (clinvar and intervar) and write to file
 master_tab <- clinvar_anno_intervar_vcf_df %>%
-  left_join(combined_tab_with_vcf_intervar[, grepl("vcf_id|intervar_adjusted|evidence|InterVar:|criterion|final_call", names(combined_tab_with_vcf_intervar))], by = "vcf_id") %>%
-  left_join(variant_summary_df, by = "vcf_id")
+  left_join(combined_tab_with_vcf_intervar[, grepl("vcf_id|intervar_adjusted|evidence|InterVar:|final_call", names(combined_tab_with_vcf_intervar))], by = "vcf_id") %>%
+  left_join(variant_summary_df, by = "vcf_id") %>%
+  left_join(autopvs1_results, by = "vcf_id")
 
 
 master_tab <- master_tab %>%

--- a/AutoGVP/input/output_colnames.tsv
+++ b/AutoGVP/input/output_colnames.tsv
@@ -1,6 +1,7 @@
 Column_name	Rename	Abridged
 CHROM	chr	T
 POS	start	T
+START	start	T
 REF	ref	T
 ALT	alt	T
 rsID	rs_id	T


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

### Purpose/implementation Section

#### What feature is being added or bug is being addressed?

Closes #144. This PR modifies autogvp and annotation filtering scripts to retain autopvs1 transcript annotation as final outputted annotation for each variant. 

#### What was your approach?

- modified `01-annotate_variants_CAVATICA_input.R` and `annotate_variants_custom_input.R` to retain autopvs1 `Feature` column. 
- modified `04-filter_gene_annotations.R` to filter annotated vcf for only `vcf_id`-`Feature` pairs in autogvp output. 

#### What GitHub issue does your pull request address?

#144 

### Directions for reviewers. Tell potential reviewers what kind of feedback you are soliciting.


#### Which areas should receive a particularly close look?

Please run shell script on both pbta and custom test files

```
bash run_autogvp.sh --workflow="cavatica" \
--vcf=input/test_pbta.single.vqsr.filtered.vep_105.vcf \
--filter_criteria='INFO/AF>=0.2 INFO/DP>=15 (gnomad_3_1_1_AF_non_cancer<0.01|gnomad_3_1_1_AF_non_cancer=".")' \
--intervar=input/test_pbta.hg38_multianno.txt.intervar \
--multianno=input/test_pbta.hg38_multianno.txt \
--autopvs1=input/test_pbta.autopvs1.tsv \
--outdir=../results \
--out="test_pbta"
```

```
bash run_autogvp.sh --workflow="custom" \
--vcf=input/test_VEP.vcf \
--clinvar=input/clinvar.vcf.gz \
--intervar=input/test_VEP.hg38_multianno.txt.intervar \
--multianno=input/test_VEP.vcf.hg38_multianno.txt \
--autopvs1=input/test_autopvs1.txt \
--outdir=../results \
--out="test_custom"
```

#### Is there anything that you want to discuss further?

There are rare instances (I believe only in the custom test files) in which variants are annotated as intergenic by VEP, but have transcript annotation by AutoPVS1. This results in `NA` annotation columns for these variants in the final output, since the AutoPVS1 transcript is not found in the VEP vcf file. I will plan to run this on larger data sets to determine if this __only__ happens with intergenic variants, in which case we can annotate them as such in the final output. 

#### Documentation Checklist

<!-- Please review and specify if it isn't applicable -->

- [X] The function has examples to showcase the usage 

