### PR TITLE
Set resolved ClinVar calls to Stars == "1"

### DIFF
--- a/AutoGVP/01-annotate_variants_CAVATICA_input.R
+++ b/AutoGVP/01-annotate_variants_CAVATICA_input.R
@@ -179,7 +179,7 @@ entries_for_cc <- filter(clinvar_anno_vcf_df, Stars == "1NR", final_call != "Ben
 
 entries_for_cc_in_submission <- inner_join(variant_summary_df, entries_for_cc, by = "vcf_id") %>%
   dplyr::mutate(final_call = ClinicalSignificance) %>%
-  dplyr::select(vcf_id, ClinicalSignificance, final_call)
+  dplyr::select(vcf_id, ClinicalSignificance, final_call, Stars)
 
 ## one Star cases that are “criteria_provided,_single_submitter” that do NOT have the B, LB, P, LP, VUS call must also go to intervar
 ## modified: any cases that do NOT have the B, LB, P, LP, VUS call must also go to intervar
@@ -241,7 +241,7 @@ clinvar_anno_intervar_vcf_df <- clinvar_anno_intervar_vcf_df %>%
   left_join(multianno_df, by = "var_id") %>%
   filter(vcf_id %in% clinvar_anno_vcf_df$vcf_id)
 
-## populate consensus call variants with invervar info
+## populate consensus call variants with intervar info
 entries_for_cc_in_submission_w_intervar <- inner_join(clinvar_anno_intervar_vcf_df, entries_for_cc_in_submission, by = "vcf_id") %>%
   dplyr::rename("Intervar_evidence" = `InterVar: InterVar and Evidence`)
 
@@ -429,10 +429,14 @@ master_tab <- full_join(master_tab, entries_for_cc_in_submission, by = "vcf_id")
   full_join(entries_for_cc_in_submission_w_intervar[c("vcf_id", "Intervar_evidence")], by = "vcf_id") %>%
   dplyr::mutate(
     Intervar_evidence = coalesce(Intervar_evidence.y, Intervar_evidence.x),
-    ClinVar_ClinicalSignificance = coalesce(ClinicalSignificance.x, ClinicalSignificance.y)
-  ) %>%
+    ClinVar_ClinicalSignificance = coalesce(ClinicalSignificance.x, ClinicalSignificance.y),
+    Stars = case_when(
+      Stars.x == "1NR" ~ "1",
+      TRUE ~ Stars.x
+    )) %>%
   dplyr::select(
     -final_call.x, -final_call.y,
+    -Stars.x, -Stars.y,
     -Intervar_evidence.x, -Intervar_evidence.y,
     -INFO, -ClinicalSignificance.x, -ClinicalSignificance.y
   )

--- a/AutoGVP/01-annotate_variants_CAVATICA_input.R
+++ b/AutoGVP/01-annotate_variants_CAVATICA_input.R
@@ -433,7 +433,8 @@ master_tab <- full_join(master_tab, entries_for_cc_in_submission, by = "vcf_id")
     Stars = case_when(
       Stars.x == "1NR" ~ "1",
       TRUE ~ Stars.x
-    )) %>%
+    )
+  ) %>%
   dplyr::select(
     -final_call.x, -final_call.y,
     -Stars.x, -Stars.y,

--- a/AutoGVP/01-annotate_variants_custom_input.R
+++ b/AutoGVP/01-annotate_variants_custom_input.R
@@ -196,7 +196,7 @@ entries_for_cc <- filter(clinvar_anno_vcf_df, Stars == "1NR", final_call != "Ben
 
 entries_for_cc_in_submission <- inner_join(variant_summary_df, entries_for_cc, by = "vcf_id") %>%
   dplyr::mutate(final_call = ClinicalSignificance) %>%
-  dplyr::select(vcf_id, ClinicalSignificance, final_call)
+  dplyr::select(vcf_id, ClinicalSignificance, final_call, Stars)
 
 ## one Star cases that are “criteria_provided,_single_submitter” that do NOT have the B, LB, P, LP, VUS call must also go to intervar
 ## modified: any cases that do NOT have the B, LB, P, LP, VUS call must also go to intervar
@@ -452,7 +452,11 @@ master_tab <- full_join(master_tab, entries_for_cc_in_submission, by = "vcf_id")
   full_join(entries_for_cc_in_submission_w_intervar[c("vcf_id", "Intervar_evidence")], by = "vcf_id") %>%
   dplyr::mutate(
     Intervar_evidence = coalesce(Intervar_evidence.y, Intervar_evidence.x),
-    ClinVar_ClinicalSignificance = coalesce(ClinicalSignificance.x, ClinicalSignificance.y)
+    ClinVar_ClinicalSignificance = coalesce(ClinicalSignificance.x, ClinicalSignificance.y),
+    Stars = case_when(
+      Stars.x == "1NR" ~ "1",
+      TRUE ~ Stars.x
+    )
   ) %>%
   dplyr::select(
     -final_call.x, -final_call.y,


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

### Purpose/implementation Section

#### What feature is being added or bug is being addressed?

Closes #148. This PR modifies code in `01-annotate_variants_*_input.R` so that ClinVar calls with conflicting interpretation that are resolved with submissions have `Stars == 1` in final output. 

#### What was your approach?

All calls with initial `Stars == "1NR` were set to `"1"` in `master_tab` output

#### What GitHub issue does your pull request address?

#148

### Directions for reviewers. Tell potential reviewers what kind of feedback you are soliciting.

#### Which areas should receive a particularly close look?

Please run autogvp bash script on test pbta and custom files, and ensure that all calls with ClinVar have a value in `clinvar_stars`. 

```
bash run_autogvp.sh --workflow="cavatica" \
--vcf=input/test_pbta.single.vqsr.filtered.vep_105.vcf \
--filter_criteria='INFO/AF>=0.2 INFO/DP>=15 (gnomad_3_1_1_AF_non_cancer<0.01|gnomad_3_1_1_AF_non_cancer=".")' \
--intervar=input/test_pbta.hg38_multianno.txt.intervar \
--multianno=input/test_pbta.hg38_multianno.txt \
--autopvs1=input/test_pbta.autopvs1.tsv \
--outdir=../results \
--out="test_pbta"
```

```
bash run_autogvp.sh --workflow="custom" \
--vcf=input/test_VEP.vcf \
--clinvar=input/clinvar.vcf.gz \
--intervar=input/test_VEP.hg38_multianno.txt.intervar \
--multianno=input/test_VEP.vcf.hg38_multianno.txt \
--autopvs1=input/test_autopvs1.txt \
--outdir=../results \
--out="test_custom"
```


#### Is there anything that you want to discuss further?

No

#### Documentation Checklist

<!-- Please review and specify if it isn't applicable -->

- [X] The function has examples to showcase the usage 

