### PR TITLE
Add output directory argument 

### DIFF
--- a/AutoGVP/01-annotate_variants_CAVATICA_input.R
+++ b/AutoGVP/01-annotate_variants_CAVATICA_input.R
@@ -27,12 +27,12 @@ suppressPackageStartupMessages({
 root_dir <- rprojroot::find_root(rprojroot::has_dir(".git"))
 analysis_dir <- file.path(root_dir, "AutoGVP")
 input_dir <- file.path(analysis_dir, "input")
-results_dir <- file.path(root_dir, "results")
+#results_dir <- file.path(root_dir, "results")
 
 # create results directory if it does not exist
-if (!dir.exists(results_dir)) {
-  dir.create(results_dir)
-}
+# if (!dir.exists(results_dir)) {
+#   dir.create(results_dir)
+# }
 
 # parse parameters
 option_list <- list(
@@ -63,6 +63,10 @@ option_list <- list(
   make_option(c("--output"),
     type = "character", default = "out",
     help = "output name"
+  ),
+  make_option(c("--outdir"),
+              type = "character", default = "../results",
+              help = "output directory"
   )
 )
 
@@ -78,7 +82,12 @@ sample_name <- opt$output
 input_variant_summary <- opt$variant_summary
 summary_level <- opt$summary_level_vcf
 output_name <- opt$output
+results_dir <- opt$outdir
 
+# create results directory if it does not exist
+if (!dir.exists(results_dir)) {
+  dir.create(results_dir)
+}
 
 ## output files
 output_tab_abr_file <- paste0(output_name, ".cavatica_input.annotations_report.abridged.tsv")

--- a/AutoGVP/01-annotate_variants_CAVATICA_input.R
+++ b/AutoGVP/01-annotate_variants_CAVATICA_input.R
@@ -27,12 +27,7 @@ suppressPackageStartupMessages({
 root_dir <- rprojroot::find_root(rprojroot::has_dir(".git"))
 analysis_dir <- file.path(root_dir, "AutoGVP")
 input_dir <- file.path(analysis_dir, "input")
-#results_dir <- file.path(root_dir, "results")
 
-# create results directory if it does not exist
-# if (!dir.exists(results_dir)) {
-#   dir.create(results_dir)
-# }
 
 # parse parameters
 option_list <- list(

--- a/AutoGVP/01-annotate_variants_custom_input.R
+++ b/AutoGVP/01-annotate_variants_custom_input.R
@@ -30,12 +30,12 @@ suppressPackageStartupMessages({
 root_dir <- rprojroot::find_root(rprojroot::has_dir(".git"))
 analysis_dir <- file.path(root_dir, "AutoGVP")
 input_dir <- file.path(analysis_dir, "input")
-results_dir <- file.path(root_dir, "results")
+#results_dir <- file.path(root_dir, "results")
 
-# create results directory if it does not exist
-if (!dir.exists(results_dir)) {
-  dir.create(results_dir)
-}
+# # create results directory if it does not exist
+# if (!dir.exists(results_dir)) {
+#   dir.create(results_dir)
+# }
 
 # parse parameters
 option_list <- list(
@@ -70,6 +70,10 @@ option_list <- list(
   make_option(c("--output"),
     type = "character", default = "out",
     help = "output name"
+  ),
+  make_option(c("--outdir"),
+              type = "character", default = "../results",
+              help = "output directory"
   )
 )
 
@@ -85,7 +89,12 @@ input_variant_summary <- opt$variant_summary
 input_multianno_file <- opt$multianno
 summary_level <- opt$summary_level
 output_name <- opt$output
+results_dir <- opt$outdir
 
+# create results directory if it does not exist
+if (!dir.exists(results_dir)) {
+  dir.create(results_dir)
+}
 
 ## output files
 output_tab_abr_file <- paste0(output_name, ".custom_input.annotations_report.abridged.tsv")

--- a/AutoGVP/01-annotate_variants_custom_input.R
+++ b/AutoGVP/01-annotate_variants_custom_input.R
@@ -30,12 +30,7 @@ suppressPackageStartupMessages({
 root_dir <- rprojroot::find_root(rprojroot::has_dir(".git"))
 analysis_dir <- file.path(root_dir, "AutoGVP")
 input_dir <- file.path(analysis_dir, "input")
-#results_dir <- file.path(root_dir, "results")
 
-# # create results directory if it does not exist
-# if (!dir.exists(results_dir)) {
-#   dir.create(results_dir)
-# }
 
 # parse parameters
 option_list <- list(

--- a/AutoGVP/04-filter_gene_annotations.R
+++ b/AutoGVP/04-filter_gene_annotations.R
@@ -27,12 +27,7 @@ suppressPackageStartupMessages({
 root_dir <- rprojroot::find_root(rprojroot::has_dir(".git"))
 analysis_dir <- file.path(root_dir, "AutoGVP")
 input_dir <- file.path(analysis_dir, "input")
-#results_dir <- file.path(root_dir, "results")
 
-# # create results directory if it does not exist
-# if (!dir.exists(results_dir)) {
-#   dir.create(results_dir)
-# }
 
 # parse parameters
 option_list <- list(

--- a/AutoGVP/04-filter_gene_annotations.R
+++ b/AutoGVP/04-filter_gene_annotations.R
@@ -27,12 +27,12 @@ suppressPackageStartupMessages({
 root_dir <- rprojroot::find_root(rprojroot::has_dir(".git"))
 analysis_dir <- file.path(root_dir, "AutoGVP")
 input_dir <- file.path(analysis_dir, "input")
-results_dir <- file.path(root_dir, "results")
+#results_dir <- file.path(root_dir, "results")
 
-# create results directory if it does not exist
-if (!dir.exists(results_dir)) {
-  dir.create(results_dir)
-}
+# # create results directory if it does not exist
+# if (!dir.exists(results_dir)) {
+#   dir.create(results_dir)
+# }
 
 # parse parameters
 option_list <- list(
@@ -47,6 +47,10 @@ option_list <- list(
   make_option(c("--output"),
     type = "character", default = "out",
     help = "output name"
+  ),
+  make_option(c("--outdir"),
+              type = "character", default = "../results",
+              help = "output directory"
   )
 )
 
@@ -56,6 +60,12 @@ opt <- parse_args(OptionParser(option_list = option_list))
 input_vcf_file <- opt$vcf
 input_autogvp_file <- opt$autogvp
 output_name <- opt$output
+results_dir <- opt$outdir
+
+# create results directory if it does not exist
+if (!dir.exists(results_dir)) {
+  dir.create(results_dir)
+}
 
 # Define output file variables
 abridged_out_file <- glue::glue("{output_name}-autogvp-annotated-abridged.tsv")

--- a/AutoGVP/run_autogvp.sh
+++ b/AutoGVP/run_autogvp.sh
@@ -99,9 +99,10 @@ if [[ "$workflow" = "cavatica" ]];then
   --intervar $intervar_input \
   --autopvs1 $autopvs1_input \
   --output $out_file \
+  --outdir $out_dir \
   --variant_summary $variant_summary_file
   
-  autogvp_output="../results/"${out_file}".cavatica_input.annotations_report.abridged.tsv"
+  autogvp_output=${out_dir}/${out_file}".cavatica_input.annotations_report.abridged.tsv"
 
   else
 
@@ -112,9 +113,10 @@ if [[ "$workflow" = "cavatica" ]];then
   --intervar $intervar_input \
   --autopvs1 $autopvs1_input \
   --output $out_file \
+  --outdir $out_dir \
   --variant_summary $variant_summary_file \
   
-  autogvp_output="../results/"${out_file}".custom_input.annotations_report.abridged.tsv"
+  autogvp_output=${out_dir}/${out_file}".custom_input.annotations_report.abridged.tsv"
 
 fi
 
@@ -131,7 +133,7 @@ vcf_parsed_file=${autogvp_input%.vcf*}."parsed.tsv"
 # Filter VCF VEP gene/transcript annotations and merge data with AutoGVP output
 echo "Filtering VEP annotations and creating final output..."
 
-Rscript 04-filter_gene_annotations.R --vcf $vcf_parsed_file --autogvp $autogvp_output --output $out_file
+Rscript 04-filter_gene_annotations.R --vcf $vcf_parsed_file --autogvp $autogvp_output --output $out_file --outdir $out_dir
 
 # Remove intermediate files
-rm $autogvp_input $vcf_parsed_file $out_dir/$autogvp_output $out_dir/$out_file.filtered_csq_subfields.tsv $out_dir/${out_file}_multianno_filtered.txt $out_dir/${out_file}_autopvs1_filtered.tsv $out_dir/${out_file}_intervar_filtered.txt
+rm $autogvp_input $vcf_parsed_file $autogvp_output $out_dir/$out_file.filtered_csq_subfields.tsv $out_dir/${out_file}_multianno_filtered.txt $out_dir/${out_file}_autopvs1_filtered.tsv $out_dir/${out_file}_intervar_filtered.txt


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

### Purpose/implementation Section

#### What feature is being added or bug is being addressed?

Closes #156. This PR adds an output directory argument that allows users to specify where output of `01-annotate_variants_*_input.R` and `04-filter_gene_annotations.R` is written. 

#### What was your approach?

- Added `outdir` argument when executing 01 and 04 scripts in `run_autogvp.sh`
- Added `outdir` to parsed parameters in 01 and 04 scripts 

#### What GitHub issue does your pull request address?

#156 

### Directions for reviewers. Tell potential reviewers what kind of feedback you are soliciting.


#### Which areas should receive a particularly close look?

Please run on test data set, and specify different `outdir` folders to check that updated code works as expected. For example: 

```
bash run_autogvp.sh --workflow="custom" \
--vcf=input/test_VEP.vcf \
--clinvar=input/clinvar.vcf.gz \
--intervar=input/test_VEP.hg38_multianno.txt.intervar \
--multianno=input/test_VEP.vcf.hg38_multianno.txt \
--autopvs1=input/test_autopvs1.txt \
--outdir=<out_dir>
--out="test_custom"
```

#### Is there anything that you want to discuss further?

No

#### Documentation Checklist

<!-- Please review and specify if it isn't applicable -->

- [X] The function has examples to showcase the usage 

