### PR TITLE
add sample id column to final output 

### DIFF
--- a/AutoGVP/02-annotate_variants_CAVATICA_input.R
+++ b/AutoGVP/02-annotate_variants_CAVATICA_input.R
@@ -473,8 +473,9 @@ master_tab <- master_tab %>%
     Reasoning_for_call == "ClinVar" ~ final_call,
     TRUE ~ str_replace(ClinVar_ClinicalSignificance, " ", "_")
   )) %>%
+  dplyr::mutate(sample_id = output_name) %>%
   dplyr::relocate(
-    CHROM, START, ID, REF, ALT,
+    sample_id, CHROM, START, ID, REF, ALT,
     final_call, Reasoning_for_call,
     Stars, ClinVar_ClinicalSignificance, Intervar_evidence
   )

--- a/AutoGVP/02-annotate_variants_custom_input.R
+++ b/AutoGVP/02-annotate_variants_custom_input.R
@@ -488,8 +488,9 @@ master_tab <- master_tab %>%
     Reasoning_for_call == "ClinVar" ~ final_call,
     TRUE ~ str_replace(ClinVar_ClinicalSignificance, " ", "_")
   )) %>%
+  dplyr::mutate(sample_id = output_name) %>%
   dplyr::relocate(any_of(c(
-    "CHROM", "POS", "START", "ID", "REF", "ALT",
+    "sample_id", "CHROM", "POS", "START", "ID", "REF", "ALT",
     "final_call", "Reasoning_for_call",
     "Stars", "ClinVar_ClinicalSignificance", "Intervar_evidence"
   )))

--- a/AutoGVP/input/output_colnames.tsv
+++ b/AutoGVP/input/output_colnames.tsv
@@ -1,4 +1,5 @@
 Column_name	Rename	Abridged
+sample_id	sample_id	T
 CHROM	chr	T
 POS	start	T
 START	start	T


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

### Purpose/implementation Section

#### What feature is being added or bug is being addressed?

closes #162. This PR updates code to include a `sample_id` column in final AutoGVP output

#### What was your approach?

The `--out` argument supplied when running `run_autogvp.sh` is added as a column in final output.  

#### What GitHub issue does your pull request address?

#162 

### Directions for reviewers. Tell potential reviewers what kind of feedback you are soliciting.


#### Which areas should receive a particularly close look?

Please run on test pbta and custom files, and confirm that `sample_id` column is present in output

```
bash run_autogvp.sh --workflow="custom" \
--vcf=input/test_VEP.vcf \
--clinvar=input/clinvar.vcf.gz \
--intervar=input/test_VEP.hg38_multianno.txt.intervar \
--multianno=input/test_VEP.vcf.hg38_multianno.txt \
--autopvs1=input/test_autopvs1.txt \
--outdir=../results \
--out="test_custom"
```

```
bash run_autogvp.sh --workflow="cavatica" \
--vcf=input/test_pbta.single.vqsr.filtered.vep_105.vcf \
--filter_criteria='INFO/AF>=0.2 INFO/DP>=15 (gnomad_3_1_1_AF_non_cancer<0.01|gnomad_3_1_1_AF_non_cancer=".")' \
--intervar=input/test_pbta.hg38_multianno.txt.intervar \
--multianno=input/test_pbta.hg38_multianno.txt \
--autopvs1=input/test_pbta.autopvs1.tsv \
--outdir=../results \
--out="test_pbta"
```



#### Is there anything that you want to discuss further?

No

#### Documentation Checklist

<!-- Please review and specify if it isn't applicable -->

- [X] The function has examples to showcase the usage 

