### PR TITLE
replace %3D with = in HGVSp

### DIFF
--- a/AutoGVP/04-filter_gene_annotations.R
+++ b/AutoGVP/04-filter_gene_annotations.R
@@ -163,6 +163,10 @@ if ("HGVSp" %in% names(merged_df)) {
     # rm ensembl transcript/protein IDs from HGVSp columns
     dplyr::mutate(
       HGVSp = str_split(HGVSp, ":", simplify = T)[, 2],
+    ) %>%
+    # replace `%3D` symbol with `=` in synonymous variant HGVSp
+    dplyr::mutate(
+      HGVSp = str_replace(HGVSp, "%3D", "=")
     )
 }
 


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

### Purpose/implementation Section

#### What feature is being added or bug is being addressed?

Closes #164. This PR replaces `%3D` with `=` in synonymous variant HGVSp values. 

#### What was your approach?

`str_replace()`

#### What GitHub issue does your pull request address?

#164 

### Directions for reviewers. Tell potential reviewers what kind of feedback you are soliciting.


#### Which areas should receive a particularly close look?



#### Is there anything that you want to discuss further?

Please run on test data set, and confirm synonymous variant `HGVSp` value have `=` and not `%3D` 

```
bash run_autogvp.sh --workflow="custom" \
--vcf=input/test_VEP.vcf \
--clinvar=input/clinvar.vcf.gz \
--intervar=input/test_VEP.hg38_multianno.txt.intervar \
--multianno=input/test_VEP.vcf.hg38_multianno.txt \
--autopvs1=input/test_autopvs1.txt \
--outdir=../results \
--out="test_custom"
```

#### Documentation Checklist

<!-- Please review and specify if it isn't applicable -->

- [X] The function has examples to showcase the usage 

