### PR TITLE
remove submissions with no assertion criteria when selecting ClinVar calls

### DIFF
--- a/AutoGVP/select-clinVar-submissions.R
+++ b/AutoGVP/select-clinVar-submissions.R
@@ -80,7 +80,8 @@ submission_summary_df <- vroom(input_submission_file,
   dplyr::mutate(DateLastEvaluated = case_when(
     DateLastEvaluated == "-" ~ NA_character_,
     TRUE ~ DateLastEvaluated
-  ))
+  )) %>%
+  dplyr::filter(!ReviewStatus %in% c("no assertion provded", "no assertion criteria provided"))
 
 # merge submission_summary and variant_summary info
 submission_merged_df <- submission_summary_df %>%

--- a/AutoGVP/select-clinVar-submissions.R
+++ b/AutoGVP/select-clinVar-submissions.R
@@ -81,7 +81,7 @@ submission_summary_df <- vroom(input_submission_file,
     DateLastEvaluated == "-" ~ NA_character_,
     TRUE ~ DateLastEvaluated
   )) %>%
-  dplyr::filter(!ReviewStatus %in% c("no assertion provded", "no assertion criteria provided"))
+  dplyr::filter(!ReviewStatus %in% c("no assertion provided", "no assertion criteria provided"))
 
 # merge submission_summary and variant_summary info
 submission_merged_df <- submission_summary_df %>%

--- a/AutoGVP/select-clinVar-submissions.R
+++ b/AutoGVP/select-clinVar-submissions.R
@@ -93,9 +93,10 @@ submission_merged_df <- submission_summary_df %>%
   dplyr::mutate(LastEvaluated = coalesce(LastEvaluated_sub, LastEvaluated_var)) %>%
   dplyr::filter(!is.na(vcf_id))
 
-# Extract submissions that match variant consensus call and are reviewed by expert panel
+# Extract submissions that match variant consensus call and are 2+ stars
 variants_no_conflict_expert <- submission_merged_df %>%
-  filter(ReviewStatus_sub == "reviewed by expert panel") %>%
+  filter(ReviewStatus_sub %in% c("practice guideline", "reviewed by expert panel", 
+                                 "criteria provided, multiple submitters, no conflicts")) %>%
   group_by(VariationID) %>%
   dplyr::arrange(desc(mdy(LastEvaluated_sub))) %>%
   dplyr::slice_head(n = 1) %>%
@@ -151,7 +152,7 @@ submission_final_df <- variants_no_conflicts %>%
   bind_rows(variants_no_conflict_expert, variants_consensus_call, variants_conflicts_phenoInfo, variants_conflicts_latest) %>%
   dplyr::mutate(
     ClinicalSignificance = ClinicalSignificance_sub,
-    ReviewStatus = ReviewStatus_var,
+    ReviewStatus = ReviewStatus_sub,
     SubmittedPhenotypeInfo = case_when(
       SubmittedPhenotypeInfo == "Not Provided" ~ NA_character_,
       TRUE ~ SubmittedPhenotypeInfo

--- a/AutoGVP/select-clinVar-submissions.R
+++ b/AutoGVP/select-clinVar-submissions.R
@@ -95,8 +95,10 @@ submission_merged_df <- submission_summary_df %>%
 
 # Extract submissions that match variant consensus call and are 2+ stars
 variants_no_conflict_expert <- submission_merged_df %>%
-  filter(ReviewStatus_sub %in% c("practice guideline", "reviewed by expert panel", 
-                                 "criteria provided, multiple submitters, no conflicts")) %>%
+  filter(ReviewStatus_sub %in% c(
+    "practice guideline", "reviewed by expert panel",
+    "criteria provided, multiple submitters, no conflicts"
+  )) %>%
   group_by(VariationID) %>%
   dplyr::arrange(desc(mdy(LastEvaluated_sub))) %>%
   dplyr::slice_head(n = 1) %>%


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

### Purpose/implementation Section

#### What feature is being added or bug is being addressed?

Closes #167. This PR modifies `select-ClinVar-submissions.R` to filter out those submissions with no assertion criteria provided

#### What was your approach?

Added filtering step when loading submissions summary: 

`dplyr::filter(!ReviewStatus %in% c("no assertion provided", "no assertion criteria provided"))`

#### What GitHub issue does your pull request address?

#167 

### Directions for reviewers. Tell potential reviewers what kind of feedback you are soliciting.


#### Which areas should receive a particularly close look?

Please run  `select-ClinVar-submissions.R` as follows: 

`Rscript select-clinVar-submissions.R --variant_summary input/variant_summary.txt.gz --submission_summary input/submission_summary.txt.gz`

Then test that autogvp runs successfully with updated `ClinVar-selected-submissions.tsv`:

```
bash run_autogvp.sh --workflow="custom" \
--vcf=input/test_VEP.vcf \
--clinvar=input/clinvar.vcf.gz \
--intervar=input/test_VEP.hg38_multianno.txt.intervar \
--multianno=input/test_VEP.vcf.hg38_multianno.txt \
--autopvs1=input/test_autopvs1.txt \
--outdir=../results \
--out="test_custom"
```

#### Is there anything that you want to discuss further?

I think it makes sense to remove these submissions when evaluating majority calls, most recent calls, or calls with associated phenotype, for cases in which variants have conflicting interpretations. But if you have other thoughts please let me know. 

#### Documentation Checklist

<!-- Please review and specify if it isn't applicable -->

- [X] The function has examples to showcase the usage 

