### PR TITLE
merge P/LP and B/LB submissions when selecting consensus call

### DIFF
--- a/AutoGVP/select-clinVar-submissions.R
+++ b/AutoGVP/select-clinVar-submissions.R
@@ -117,7 +117,7 @@ variants_no_conflicts <- submission_merged_df %>%
 # Identify cases where a majority pathogenicity call has been made for variants
 consensus_calls <- submission_merged_df %>%
   dplyr::filter(!VariationID %in% c(variants_no_conflict_expert$VariationID, variants_no_conflicts$VariationID)) %>%
-  # Here, we will group B+LB and P+LP together to identify majority calls 
+  # Here, we will group B+LB and P+LP together to identify majority calls
   dplyr::mutate(ClinSig = case_when(
     ClinicalSignificance_sub %in% c("Pathogenic", "Likely pathogenic") ~ "P/LP",
     ClinicalSignificance_sub %in% c("Benign", "Likely benign") ~ "B/LB",

--- a/AutoGVP/select-clinVar-submissions.R
+++ b/AutoGVP/select-clinVar-submissions.R
@@ -114,21 +114,35 @@ variants_no_conflicts <- submission_merged_df %>%
   dplyr::slice_head(n = 1) %>%
   ungroup()
 
-# Identify cases where a majority pathnogenicity calls has been made for variants
+# Identify cases where a majority pathogenicity call has been made for variants
 consensus_calls <- submission_merged_df %>%
   dplyr::filter(!VariationID %in% c(variants_no_conflict_expert$VariationID, variants_no_conflicts$VariationID)) %>%
-  count(VariationID, ClinicalSignificance_sub) %>%
+  # Here, we will group B+LB and P+LP together to identify majority calls 
+  dplyr::mutate(ClinSig = case_when(
+    ClinicalSignificance_sub %in% c("Pathogenic", "Likely pathogenic") ~ "P/LP",
+    ClinicalSignificance_sub %in% c("Benign", "Likely benign") ~ "B/LB",
+    ClinicalSignificance_sub == "Uncertain significance" ~ "VUS",
+    TRUE ~ NA_character_
+  )) %>%
+  count(VariationID, ClinSig) %>%
   group_by(VariationID) %>%
   dplyr::filter(n == max(n)) %>%
   dplyr::filter(!VariationID %in% VariationID[duplicated(VariationID)])
 
 # Extract variants with majority calls
 variants_consensus_call <- submission_merged_df %>%
-  dplyr::filter(glue::glue("{VariationID}-{ClinicalSignificance_sub}") %in% glue::glue("{consensus_calls$VariationID}-{consensus_calls$ClinicalSignificance_sub}")) %>%
+  dplyr::mutate(ClinSig = case_when(
+    ClinicalSignificance_sub %in% c("Pathogenic", "Likely pathogenic") ~ "P/LP",
+    ClinicalSignificance_sub %in% c("Benign", "Likely benign") ~ "B/LB",
+    ClinicalSignificance_sub == "Uncertain significance" ~ "VUS",
+    TRUE ~ NA_character_
+  )) %>%
+  dplyr::filter(glue::glue("{VariationID}-{ClinSig}") %in% glue::glue("{consensus_calls$VariationID}-{consensus_calls$ClinSig}")) %>%
   group_by(VariationID) %>%
   dplyr::arrange(desc(mdy(LastEvaluated_sub))) %>%
   dplyr::slice_head(n = 1) %>%
-  ungroup()
+  ungroup() %>%
+  dplyr::select(-ClinSig)
 
 # Identify variants with conflicting ClinSigs, but where a P-LP call has an associated phenotypeInfo
 variants_conflicts_phenoInfo <- submission_merged_df %>%


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

### Purpose/implementation Section

#### What feature is being added or bug is being addressed?

Closes #169. This PR updates selection of ClinVar submissions based on consensus call by merging L/LP and B/LB variants together when counting submissions, rather than considering these classifications separately as was done previously. 

#### What was your approach?

Modified code in `select-clinVar-submissions.R` to create a new column `ClinSig` that takes values `P/LP`, `B/LB` and `VUS`. Submissions for each `VariationID` were counted based on `ClinSig` column to identify variants with a majority call. Then, among calls in this majority group, the classification at the most recently evaluated date is taken as final call. 

#### What GitHub issue does your pull request address?

#169 

### Directions for reviewers. Tell potential reviewers what kind of feedback you are soliciting.


#### Which areas should receive a particularly close look?

Please review updated code and run `select-clinVar-submissions.R`: 

`Rscript select-clinVar-submissions.R --variant_summary input/variant_summary.txt.gz --submission_summary input/submission_summary.txt.gz`

#### Is there anything that you want to discuss further?

No

#### Documentation Checklist

<!-- Please review and specify if it isn't applicable -->

- [X] The function has examples to showcase the usage 

