### PR TITLE
remove associated pheno criterion from ClinVar submission selection

### DIFF
--- a/AutoGVP/select-clinVar-submissions.R
+++ b/AutoGVP/select-clinVar-submissions.R
@@ -130,7 +130,7 @@ variants_consensus_call <- submission_merged_df %>%
   dplyr::slice_head(n = 1) %>%
   ungroup()
 
-# Identify variants with conflicting ClinSigs, and retain call at last date evaluated
+# Identify variants with conflicting ClinSigs, and retain call at most recent date evaluated
 variants_conflicts_latest <- submission_merged_df %>%
   dplyr::filter(!VariationID %in% c(variants_no_conflict_expert$VariationID, variants_no_conflicts$VariationID, variants_consensus_call$VariationID)) %>%
   dplyr::filter(ClinicalSignificance_var != ClinicalSignificance_sub) %>%

--- a/AutoGVP/select-clinVar-submissions.R
+++ b/AutoGVP/select-clinVar-submissions.R
@@ -9,7 +9,7 @@
 # usage: select-clinVar-submissions.R --variant_summary <variant file>
 #                                       --submission_summary <submission file>
 #
-# NOTE: this script must be run BEFORE running run-autogvp.sh
+# NOTE: this script must be run BEFORE running run_autogvp.sh
 ################################################################################
 
 suppressPackageStartupMessages({
@@ -130,19 +130,9 @@ variants_consensus_call <- submission_merged_df %>%
   dplyr::slice_head(n = 1) %>%
   ungroup()
 
-# Identify variants with conflicting ClinSigs, but where a P-LP call has an associated phenotypeInfo
-variants_conflicts_phenoInfo <- submission_merged_df %>%
-  dplyr::filter(!VariationID %in% c(variants_no_conflict_expert$VariationID, variants_no_conflicts$VariationID, variants_consensus_call$VariationID)) %>%
-  dplyr::filter(ClinicalSignificance_var != ClinicalSignificance_sub) %>%
-  dplyr::filter(grepl("Pathogenic|Likely pathogenic", ClinicalSignificance_sub) & (!is.na(SubmittedPhenotypeInfo) | !is.na(ReportedPhenotypeInfo)) & !grepl("not provided|not specified", ReportedPhenotypeInfo)) %>%
-  group_by(VariationID) %>%
-  dplyr::arrange(desc(mdy(LastEvaluated_sub))) %>%
-  dplyr::slice_head(n = 1) %>%
-  ungroup()
-
 # Identify variants with conflicting ClinSigs, and retain call at last date evaluated
 variants_conflicts_latest <- submission_merged_df %>%
-  dplyr::filter(!VariationID %in% c(variants_no_conflict_expert$VariationID, variants_no_conflicts$VariationID, variants_consensus_call$VariationID, variants_conflicts_phenoInfo$VariationID)) %>%
+  dplyr::filter(!VariationID %in% c(variants_no_conflict_expert$VariationID, variants_no_conflicts$VariationID, variants_consensus_call$VariationID)) %>%
   dplyr::filter(ClinicalSignificance_var != ClinicalSignificance_sub) %>%
   group_by(VariationID) %>%
   dplyr::arrange(desc(mdy(LastEvaluated_sub))) %>%
@@ -151,7 +141,7 @@ variants_conflicts_latest <- submission_merged_df %>%
 
 # create final df and take ClinSig calls from submission summary
 submission_final_df <- variants_no_conflicts %>%
-  bind_rows(variants_no_conflict_expert, variants_consensus_call, variants_conflicts_phenoInfo, variants_conflicts_latest) %>%
+  bind_rows(variants_no_conflict_expert, variants_consensus_call, variants_conflicts_latest) %>%
   dplyr::mutate(
     ClinicalSignificance = ClinicalSignificance_sub,
     ReviewStatus = ReviewStatus_sub,


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

### Purpose/implementation Section

#### What feature is being added or bug is being addressed?

Closes #171. This PR removes the criterion that prioritizes P/LP variant submissions with associated phenotypes. 

#### What was your approach?

Modified `select-clinVar-submissions.R` to remove this code chunk from script. 

#### What GitHub issue does your pull request address?

#171 

### Directions for reviewers. Tell potential reviewers what kind of feedback you are soliciting.


#### Which areas should receive a particularly close look?

Please review updated script and run `select-ClinVar-submissions.R`:

`Rscript select-clinVar-submissions.R --variant_summary input/variant_summary.txt.gz --submission_summary input/submission_summary.txt.gz`

#### Is there anything that you want to discuss further?

No

#### Documentation Checklist

<!-- Please review and specify if it isn't applicable -->

- [X] The function has examples to showcase the usage 

