### PR TITLE
Include variant depth in final output

### DIFF
--- a/AutoGVP/input/output_colnames.tsv
+++ b/AutoGVP/input/output_colnames.tsv
@@ -35,6 +35,7 @@ evidenceBP	BP_autogvp	F
 intervar_adjusted	intervar_adjusted	F
 AC	AC	F
 AF	AF	F
+DP	DP	F
 ALLELEID	ALLELEID	F
 AN	AN	F
 BaseQRankSum	BaseQRankSum	F


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

### Purpose/implementation Section

#### What feature is being added or bug is being addressed?

Closes #175. This PR adds DP (from FORMAT field) to `output_colnames.tsv` so that it is included in full autogvp output. 

#### What was your approach?



#### What GitHub issue does your pull request address?

#175 

### Directions for reviewers. Tell potential reviewers what kind of feedback you are soliciting.


#### Which areas should receive a particularly close look?

Please run on test files and ensure DP is included in output: 

```
bash run_autogvp.sh --workflow="cavatica" \
--vcf=input/test_pbta.single.vqsr.filtered.vep_105.vcf \
--filter_criteria='INFO/AF>=0.2 FORMAT/DP>=10 (gnomad_3_1_1_AF_non_cancer<0.001|gnomad_3_1_1_AF_non_cancer=".")' \
--intervar=input/test_pbta.hg38_multianno.txt.intervar \
--multianno=input/test_pbta.hg38_multianno.txt \
--autopvs1=input/test_pbta.autopvs1.tsv \
--outdir=../results \
--out="test_pbta"
```

#### Is there anything that you want to discuss further?

NOTE: these test files are now outdated since upstream updates to autopvs1, so please just confirm presence of `DP` column in output. 

#### Documentation Checklist

<!-- Please review and specify if it isn't applicable -->

- [X] The function has examples to showcase the usage 

