### PR TITLE
Take original intervar call when PVS1=0

### DIFF
--- a/AutoGVP/02-annotate_variants_CAVATICA_input.R
+++ b/AutoGVP/02-annotate_variants_CAVATICA_input.R
@@ -327,70 +327,73 @@ combined_tab_with_vcf_intervar <- autopvs1_results %>%
       criterion == "IC5") & evidencePVS1 == 1, 0, as.double(evidencePVS1)),
 
     ## adjust variables based on given rules described in README
-    final_call = ifelse((evidencePVS1 == 1) & (evidencePVS1 == 1 &
-      ((evidencePS >= 1) |
-        (evidencePM >= 2) |
-        (evidencePM == 1 & evidencePP == 1) |
-        (evidencePP >= 2)) &
-      ((evidenceBA1) == 1 |
-        (evidenceBS >= 2) |
-        (evidenceBP >= 2) |
-        (evidenceBS >= 1 & evidenceBP >= 1) |
-        (evidenceBA1 == 1 & (evidenceBS >= 1 | evidenceBP >= 1)))), "Uncertain_significance",
-    ifelse(((evidencePVS1 == 1) & (evidencePS >= 2) &
-      ((evidenceBA1) == 1 |
-        (evidenceBS >= 2) |
-        (evidenceBP >= 2) |
-        (evidenceBS >= 1 & evidenceBP >= 1) |
-        (evidenceBA1 == 1 & (evidenceBS >= 1 | evidenceBP >= 1)))), "Uncertain_significance",
-    ifelse(((evidencePVS1 == 1) & (evidencePS == 1 &
-      (evidencePM >= 3 |
-        (evidencePM == 2 & evidencePP >= 2) |
-        (evidencePM == 1 & evidencePP >= 4))) &
-      ((evidenceBA1) == 1 |
-        (evidenceBS >= 2) |
-        (evidenceBP >= 2) |
-        (evidenceBS >= 1 & evidenceBP >= 1) |
-        (evidenceBA1 == 1 & (evidenceBS >= 1 | evidenceBP >= 1)))), "Uncertain_significance",
-    ifelse((((evidencePVS1 == 1) & (evidencePVS1 == 1 & evidencePM == 1) |
-      (evidencePS == 1 & evidencePM >= 1) |
-      (evidencePS == 1 & evidencePP >= 2) |
-      (evidencePM >= 3) |
-      (evidencePM == 2 & evidencePP >= 2) |
-      (evidencePM == 1 & evidencePP >= 4)) &
-      ((evidenceBA1) == 1 |
-        (evidenceBS >= 2) |
-        (evidenceBP >= 2) |
-        (evidenceBS >= 1 & evidenceBP >= 1) |
-        (evidenceBA1 == 1 & (evidenceBS >= 1 | evidenceBP >= 1)))), "Uncertain_significance",
-    ifelse((evidencePVS1 == 1) & (evidencePVS1 == 1 &
-      ((evidencePS >= 1) |
-        (evidencePM >= 2) |
-        (evidencePM == 1 & evidencePP == 1) |
-        (evidencePP >= 2))), "Pathogenic",
-    ifelse((evidencePVS1 == 1) & (evidencePS >= 2), "Pathogenic",
-      ifelse((evidencePVS1 == 0) & (evidencePS == 1 &
-        (evidencePM >= 3 |
-          (evidencePM == 2 & evidencePP >= 2) |
-          (evidencePM == 1 & evidencePP >= 4))), "Pathogenic",
-      ifelse((evidencePVS1 == 1) & (evidencePVS1 == 1 & evidencePM == 1) |
-        (evidencePS == 1 & evidencePM >= 1) |
-        (evidencePS == 1 & evidencePP >= 2) |
-        (evidencePM >= 3) |
-        (evidencePM == 2 & evidencePP >= 2) |
-        (evidencePM == 1 & evidencePP >= 4), "Likely_pathogenic",
-      ifelse((evidencePVS1 == 1) & (evidenceBA1 == 1) |
-        (evidenceBS >= 2), "Benign",
-      ifelse((evidencePVS1 == 1) & (evidenceBS == 1 & evidenceBP == 1) |
-        (evidenceBP >= 2), "Likely_benign", "Uncertain_significance")
-      )
-      )
-      )
-    )
-    )
-    )
-    )
-    )
+    final_call = ifelse(intervar_adjusted == "No", 
+                        sub(".*InterVar: ", "", sub("\\ P.*", "", `InterVar: InterVar and Evidence`)),
+                        ifelse((evidencePVS1 == 1) & (evidencePVS1 == 1 &
+                                                        ((evidencePS >= 1) |
+                                                           (evidencePM >= 2) |
+                                                           (evidencePM == 1 & evidencePP == 1) |
+                                                           (evidencePP >= 2)) &
+                                                        ((evidenceBA1) == 1 |
+                                                           (evidenceBS >= 2) |
+                                                           (evidenceBP >= 2) |
+                                                           (evidenceBS >= 1 & evidenceBP >= 1) |
+                                                           (evidenceBA1 == 1 & (evidenceBS >= 1 | evidenceBP >= 1)))), "Uncertain_significance",
+                               ifelse(((evidencePVS1 == 1) & (evidencePS >= 2) &
+                                         ((evidenceBA1) == 1 |
+                                            (evidenceBS >= 2) |
+                                            (evidenceBP >= 2) |
+                                            (evidenceBS >= 1 & evidenceBP >= 1) |
+                                            (evidenceBA1 == 1 & (evidenceBS >= 1 | evidenceBP >= 1)))), "Uncertain_significance",
+                                      ifelse(((evidencePVS1 == 1) & (evidencePS == 1 &
+                                                                       (evidencePM >= 3 |
+                                                                          (evidencePM == 2 & evidencePP >= 2) |
+                                                                          (evidencePM == 1 & evidencePP >= 4))) &
+                                                ((evidenceBA1) == 1 |
+                                                   (evidenceBS >= 2) |
+                                                   (evidenceBP >= 2) |
+                                                   (evidenceBS >= 1 & evidenceBP >= 1) |
+                                                   (evidenceBA1 == 1 & (evidenceBS >= 1 | evidenceBP >= 1)))), "Uncertain_significance",
+                                             ifelse((((evidencePVS1 == 1) & (evidencePVS1 == 1 & evidencePM == 1) |
+                                                        (evidencePS == 1 & evidencePM >= 1) |
+                                                        (evidencePS == 1 & evidencePP >= 2) |
+                                                        (evidencePM >= 3) |
+                                                        (evidencePM == 2 & evidencePP >= 2) |
+                                                        (evidencePM == 1 & evidencePP >= 4)) &
+                                                       ((evidenceBA1) == 1 |
+                                                          (evidenceBS >= 2) |
+                                                          (evidenceBP >= 2) |
+                                                          (evidenceBS >= 1 & evidenceBP >= 1) |
+                                                          (evidenceBA1 == 1 & (evidenceBS >= 1 | evidenceBP >= 1)))), "Uncertain_significance",
+                                                    ifelse((evidencePVS1 == 1) & (evidencePVS1 == 1 &
+                                                                                    ((evidencePS >= 1) |
+                                                                                       (evidencePM >= 2) |
+                                                                                       (evidencePM == 1 & evidencePP == 1) |
+                                                                                       (evidencePP >= 2))), "Pathogenic",
+                                                           ifelse((evidencePVS1 == 1) & (evidencePS >= 2), "Pathogenic",
+                                                                  ifelse((evidencePVS1 == 0) & (evidencePS == 1 &
+                                                                                                  (evidencePM >= 3 |
+                                                                                                     (evidencePM == 2 & evidencePP >= 2) |
+                                                                                                     (evidencePM == 1 & evidencePP >= 4))), "Pathogenic",
+                                                                         ifelse((evidencePVS1 == 1) & (evidencePVS1 == 1 & evidencePM == 1) |
+                                                                                  (evidencePS == 1 & evidencePM >= 1) |
+                                                                                  (evidencePS == 1 & evidencePP >= 2) |
+                                                                                  (evidencePM >= 3) |
+                                                                                  (evidencePM == 2 & evidencePP >= 2) |
+                                                                                  (evidencePM == 1 & evidencePP >= 4), "Likely_pathogenic",
+                                                                                ifelse((evidencePVS1 == 1) & (evidenceBA1 == 1) |
+                                                                                         (evidenceBS >= 2), "Benign",
+                                                                                       ifelse((evidencePVS1 == 1) & (evidenceBS == 1 & evidenceBP == 1) |
+                                                                                                (evidenceBP >= 2), "Likely_benign", "Uncertain_significance")
+                                                                                )
+                                                                         )
+                                                                  )
+                                                           )
+                                                    )
+                                             )
+                                      )
+                               )
+                        )
     )
   )
 

--- a/AutoGVP/02-annotate_variants_CAVATICA_input.R
+++ b/AutoGVP/02-annotate_variants_CAVATICA_input.R
@@ -327,73 +327,73 @@ combined_tab_with_vcf_intervar <- autopvs1_results %>%
       criterion == "IC5") & evidencePVS1 == 1, 0, as.double(evidencePVS1)),
 
     ## adjust variables based on given rules described in README
-    final_call = ifelse(intervar_adjusted == "No", 
-                        sub(".*InterVar: ", "", sub("\\ P.*", "", `InterVar: InterVar and Evidence`)),
-                        ifelse((evidencePVS1 == 1) & (evidencePVS1 == 1 &
-                                                        ((evidencePS >= 1) |
-                                                           (evidencePM >= 2) |
-                                                           (evidencePM == 1 & evidencePP == 1) |
-                                                           (evidencePP >= 2)) &
-                                                        ((evidenceBA1) == 1 |
-                                                           (evidenceBS >= 2) |
-                                                           (evidenceBP >= 2) |
-                                                           (evidenceBS >= 1 & evidenceBP >= 1) |
-                                                           (evidenceBA1 == 1 & (evidenceBS >= 1 | evidenceBP >= 1)))), "Uncertain_significance",
-                               ifelse(((evidencePVS1 == 1) & (evidencePS >= 2) &
-                                         ((evidenceBA1) == 1 |
-                                            (evidenceBS >= 2) |
-                                            (evidenceBP >= 2) |
-                                            (evidenceBS >= 1 & evidenceBP >= 1) |
-                                            (evidenceBA1 == 1 & (evidenceBS >= 1 | evidenceBP >= 1)))), "Uncertain_significance",
-                                      ifelse(((evidencePVS1 == 1) & (evidencePS == 1 &
-                                                                       (evidencePM >= 3 |
-                                                                          (evidencePM == 2 & evidencePP >= 2) |
-                                                                          (evidencePM == 1 & evidencePP >= 4))) &
-                                                ((evidenceBA1) == 1 |
-                                                   (evidenceBS >= 2) |
-                                                   (evidenceBP >= 2) |
-                                                   (evidenceBS >= 1 & evidenceBP >= 1) |
-                                                   (evidenceBA1 == 1 & (evidenceBS >= 1 | evidenceBP >= 1)))), "Uncertain_significance",
-                                             ifelse((((evidencePVS1 == 1) & (evidencePVS1 == 1 & evidencePM == 1) |
-                                                        (evidencePS == 1 & evidencePM >= 1) |
-                                                        (evidencePS == 1 & evidencePP >= 2) |
-                                                        (evidencePM >= 3) |
-                                                        (evidencePM == 2 & evidencePP >= 2) |
-                                                        (evidencePM == 1 & evidencePP >= 4)) &
-                                                       ((evidenceBA1) == 1 |
-                                                          (evidenceBS >= 2) |
-                                                          (evidenceBP >= 2) |
-                                                          (evidenceBS >= 1 & evidenceBP >= 1) |
-                                                          (evidenceBA1 == 1 & (evidenceBS >= 1 | evidenceBP >= 1)))), "Uncertain_significance",
-                                                    ifelse((evidencePVS1 == 1) & (evidencePVS1 == 1 &
-                                                                                    ((evidencePS >= 1) |
-                                                                                       (evidencePM >= 2) |
-                                                                                       (evidencePM == 1 & evidencePP == 1) |
-                                                                                       (evidencePP >= 2))), "Pathogenic",
-                                                           ifelse((evidencePVS1 == 1) & (evidencePS >= 2), "Pathogenic",
-                                                                  ifelse((evidencePVS1 == 0) & (evidencePS == 1 &
-                                                                                                  (evidencePM >= 3 |
-                                                                                                     (evidencePM == 2 & evidencePP >= 2) |
-                                                                                                     (evidencePM == 1 & evidencePP >= 4))), "Pathogenic",
-                                                                         ifelse((evidencePVS1 == 1) & (evidencePVS1 == 1 & evidencePM == 1) |
-                                                                                  (evidencePS == 1 & evidencePM >= 1) |
-                                                                                  (evidencePS == 1 & evidencePP >= 2) |
-                                                                                  (evidencePM >= 3) |
-                                                                                  (evidencePM == 2 & evidencePP >= 2) |
-                                                                                  (evidencePM == 1 & evidencePP >= 4), "Likely_pathogenic",
-                                                                                ifelse((evidencePVS1 == 1) & (evidenceBA1 == 1) |
-                                                                                         (evidenceBS >= 2), "Benign",
-                                                                                       ifelse((evidencePVS1 == 1) & (evidenceBS == 1 & evidenceBP == 1) |
-                                                                                                (evidenceBP >= 2), "Likely_benign", "Uncertain_significance")
-                                                                                )
-                                                                         )
-                                                                  )
-                                                           )
-                                                    )
-                                             )
-                                      )
-                               )
-                        )
+    final_call = ifelse(intervar_adjusted == "No",
+      sub(".*InterVar: ", "", sub("\\ P.*", "", `InterVar: InterVar and Evidence`)),
+      ifelse((evidencePVS1 == 1) & (evidencePVS1 == 1 &
+        ((evidencePS >= 1) |
+          (evidencePM >= 2) |
+          (evidencePM == 1 & evidencePP == 1) |
+          (evidencePP >= 2)) &
+        ((evidenceBA1) == 1 |
+          (evidenceBS >= 2) |
+          (evidenceBP >= 2) |
+          (evidenceBS >= 1 & evidenceBP >= 1) |
+          (evidenceBA1 == 1 & (evidenceBS >= 1 | evidenceBP >= 1)))), "Uncertain_significance",
+      ifelse(((evidencePVS1 == 1) & (evidencePS >= 2) &
+        ((evidenceBA1) == 1 |
+          (evidenceBS >= 2) |
+          (evidenceBP >= 2) |
+          (evidenceBS >= 1 & evidenceBP >= 1) |
+          (evidenceBA1 == 1 & (evidenceBS >= 1 | evidenceBP >= 1)))), "Uncertain_significance",
+      ifelse(((evidencePVS1 == 1) & (evidencePS == 1 &
+        (evidencePM >= 3 |
+          (evidencePM == 2 & evidencePP >= 2) |
+          (evidencePM == 1 & evidencePP >= 4))) &
+        ((evidenceBA1) == 1 |
+          (evidenceBS >= 2) |
+          (evidenceBP >= 2) |
+          (evidenceBS >= 1 & evidenceBP >= 1) |
+          (evidenceBA1 == 1 & (evidenceBS >= 1 | evidenceBP >= 1)))), "Uncertain_significance",
+      ifelse((((evidencePVS1 == 1) & (evidencePVS1 == 1 & evidencePM == 1) |
+        (evidencePS == 1 & evidencePM >= 1) |
+        (evidencePS == 1 & evidencePP >= 2) |
+        (evidencePM >= 3) |
+        (evidencePM == 2 & evidencePP >= 2) |
+        (evidencePM == 1 & evidencePP >= 4)) &
+        ((evidenceBA1) == 1 |
+          (evidenceBS >= 2) |
+          (evidenceBP >= 2) |
+          (evidenceBS >= 1 & evidenceBP >= 1) |
+          (evidenceBA1 == 1 & (evidenceBS >= 1 | evidenceBP >= 1)))), "Uncertain_significance",
+      ifelse((evidencePVS1 == 1) & (evidencePVS1 == 1 &
+        ((evidencePS >= 1) |
+          (evidencePM >= 2) |
+          (evidencePM == 1 & evidencePP == 1) |
+          (evidencePP >= 2))), "Pathogenic",
+      ifelse((evidencePVS1 == 1) & (evidencePS >= 2), "Pathogenic",
+        ifelse((evidencePVS1 == 0) & (evidencePS == 1 &
+          (evidencePM >= 3 |
+            (evidencePM == 2 & evidencePP >= 2) |
+            (evidencePM == 1 & evidencePP >= 4))), "Pathogenic",
+        ifelse((evidencePVS1 == 1) & (evidencePVS1 == 1 & evidencePM == 1) |
+          (evidencePS == 1 & evidencePM >= 1) |
+          (evidencePS == 1 & evidencePP >= 2) |
+          (evidencePM >= 3) |
+          (evidencePM == 2 & evidencePP >= 2) |
+          (evidencePM == 1 & evidencePP >= 4), "Likely_pathogenic",
+        ifelse((evidencePVS1 == 1) & (evidenceBA1 == 1) |
+          (evidenceBS >= 2), "Benign",
+        ifelse((evidencePVS1 == 1) & (evidenceBS == 1 & evidenceBP == 1) |
+          (evidenceBP >= 2), "Likely_benign", "Uncertain_significance")
+        )
+        )
+        )
+      )
+      )
+      )
+      )
+      )
+      )
     )
   )
 

--- a/AutoGVP/02-annotate_variants_custom_input.R
+++ b/AutoGVP/02-annotate_variants_custom_input.R
@@ -345,74 +345,74 @@ combined_tab_with_vcf_intervar <- autopvs1_results %>%
       criterion == "IC5") & evidencePVS1 == 1, 0, as.double(evidencePVS1)),
 
     ## adjust variables based on given rules described in README
-    final_call = ifelse(intervar_adjusted == "No", 
-                        sub(".*InterVar: ", "", sub("\\ P.*", "", `InterVar: InterVar and Evidence`)),
-    ifelse((evidencePVS1 == 1) & (evidencePVS1 == 1 &
-      ((evidencePS >= 1) |
-        (evidencePM >= 2) |
-        (evidencePM == 1 & evidencePP == 1) |
-        (evidencePP >= 2)) &
-      ((evidenceBA1) == 1 |
-        (evidenceBS >= 2) |
-        (evidenceBP >= 2) |
-        (evidenceBS >= 1 & evidenceBP >= 1) |
-        (evidenceBA1 == 1 & (evidenceBS >= 1 | evidenceBP >= 1)))), "Uncertain_significance",
-    ifelse(((evidencePVS1 == 1) & (evidencePS >= 2) &
-      ((evidenceBA1) == 1 |
-        (evidenceBS >= 2) |
-        (evidenceBP >= 2) |
-        (evidenceBS >= 1 & evidenceBP >= 1) |
-        (evidenceBA1 == 1 & (evidenceBS >= 1 | evidenceBP >= 1)))), "Uncertain_significance",
-    ifelse(((evidencePVS1 == 1) & (evidencePS == 1 &
-      (evidencePM >= 3 |
-        (evidencePM == 2 & evidencePP >= 2) |
-        (evidencePM == 1 & evidencePP >= 4))) &
-      ((evidenceBA1) == 1 |
-        (evidenceBS >= 2) |
-        (evidenceBP >= 2) |
-        (evidenceBS >= 1 & evidenceBP >= 1) |
-        (evidenceBA1 == 1 & (evidenceBS >= 1 | evidenceBP >= 1)))), "Uncertain_significance",
-    ifelse((((evidencePVS1 == 1) & (evidencePVS1 == 1 & evidencePM == 1) |
-      (evidencePS == 1 & evidencePM >= 1) |
-      (evidencePS == 1 & evidencePP >= 2) |
-      (evidencePM >= 3) |
-      (evidencePM == 2 & evidencePP >= 2) |
-      (evidencePM == 1 & evidencePP >= 4)) &
-      ((evidenceBA1) == 1 |
-        (evidenceBS >= 2) |
-        (evidenceBP >= 2) |
-        (evidenceBS >= 1 & evidenceBP >= 1) |
-        (evidenceBA1 == 1 & (evidenceBS >= 1 | evidenceBP >= 1)))), "Uncertain_significance",
-    ifelse((evidencePVS1 == 1) & (evidencePVS1 == 1 &
-      ((evidencePS >= 1) |
-        (evidencePM >= 2) |
-        (evidencePM == 1 & evidencePP == 1) |
-        (evidencePP >= 2))), "Pathogenic",
-    ifelse((evidencePVS1 == 1) & (evidencePS >= 2), "Pathogenic",
-      ifelse((evidencePVS1 == 0) & (evidencePS == 1 &
+    final_call = ifelse(intervar_adjusted == "No",
+      sub(".*InterVar: ", "", sub("\\ P.*", "", `InterVar: InterVar and Evidence`)),
+      ifelse((evidencePVS1 == 1) & (evidencePVS1 == 1 &
+        ((evidencePS >= 1) |
+          (evidencePM >= 2) |
+          (evidencePM == 1 & evidencePP == 1) |
+          (evidencePP >= 2)) &
+        ((evidenceBA1) == 1 |
+          (evidenceBS >= 2) |
+          (evidenceBP >= 2) |
+          (evidenceBS >= 1 & evidenceBP >= 1) |
+          (evidenceBA1 == 1 & (evidenceBS >= 1 | evidenceBP >= 1)))), "Uncertain_significance",
+      ifelse(((evidencePVS1 == 1) & (evidencePS >= 2) &
+        ((evidenceBA1) == 1 |
+          (evidenceBS >= 2) |
+          (evidenceBP >= 2) |
+          (evidenceBS >= 1 & evidenceBP >= 1) |
+          (evidenceBA1 == 1 & (evidenceBS >= 1 | evidenceBP >= 1)))), "Uncertain_significance",
+      ifelse(((evidencePVS1 == 1) & (evidencePS == 1 &
         (evidencePM >= 3 |
           (evidencePM == 2 & evidencePP >= 2) |
-          (evidencePM == 1 & evidencePP >= 4))), "Pathogenic",
-      ifelse((evidencePVS1 == 1) & (evidencePVS1 == 1 & evidencePM == 1) |
+          (evidencePM == 1 & evidencePP >= 4))) &
+        ((evidenceBA1) == 1 |
+          (evidenceBS >= 2) |
+          (evidenceBP >= 2) |
+          (evidenceBS >= 1 & evidenceBP >= 1) |
+          (evidenceBA1 == 1 & (evidenceBS >= 1 | evidenceBP >= 1)))), "Uncertain_significance",
+      ifelse((((evidencePVS1 == 1) & (evidencePVS1 == 1 & evidencePM == 1) |
         (evidencePS == 1 & evidencePM >= 1) |
         (evidencePS == 1 & evidencePP >= 2) |
         (evidencePM >= 3) |
         (evidencePM == 2 & evidencePP >= 2) |
-        (evidencePM == 1 & evidencePP >= 4), "Likely_pathogenic",
-      ifelse((evidencePVS1 == 1) & (evidenceBA1 == 1) |
-        (evidenceBS >= 2), "Benign",
-      ifelse((evidencePVS1 == 1) & (evidenceBS == 1 & evidenceBP == 1) |
-        (evidenceBP >= 2), "Likely_benign", "Uncertain_significance")
+        (evidencePM == 1 & evidencePP >= 4)) &
+        ((evidenceBA1) == 1 |
+          (evidenceBS >= 2) |
+          (evidenceBP >= 2) |
+          (evidenceBS >= 1 & evidenceBP >= 1) |
+          (evidenceBA1 == 1 & (evidenceBS >= 1 | evidenceBP >= 1)))), "Uncertain_significance",
+      ifelse((evidencePVS1 == 1) & (evidencePVS1 == 1 &
+        ((evidencePS >= 1) |
+          (evidencePM >= 2) |
+          (evidencePM == 1 & evidencePP == 1) |
+          (evidencePP >= 2))), "Pathogenic",
+      ifelse((evidencePVS1 == 1) & (evidencePS >= 2), "Pathogenic",
+        ifelse((evidencePVS1 == 0) & (evidencePS == 1 &
+          (evidencePM >= 3 |
+            (evidencePM == 2 & evidencePP >= 2) |
+            (evidencePM == 1 & evidencePP >= 4))), "Pathogenic",
+        ifelse((evidencePVS1 == 1) & (evidencePVS1 == 1 & evidencePM == 1) |
+          (evidencePS == 1 & evidencePM >= 1) |
+          (evidencePS == 1 & evidencePP >= 2) |
+          (evidencePM >= 3) |
+          (evidencePM == 2 & evidencePP >= 2) |
+          (evidencePM == 1 & evidencePP >= 4), "Likely_pathogenic",
+        ifelse((evidencePVS1 == 1) & (evidenceBA1 == 1) |
+          (evidenceBS >= 2), "Benign",
+        ifelse((evidencePVS1 == 1) & (evidenceBS == 1 & evidenceBP == 1) |
+          (evidenceBP >= 2), "Likely_benign", "Uncertain_significance")
+        )
+        )
+        )
+      )
+      )
+      )
       )
       )
       )
     )
-    )
-    )
-    )
-    )
-    )
-  )
   )
 
 ## merge tables together (clinvar and intervar) and write to file

--- a/AutoGVP/02-annotate_variants_custom_input.R
+++ b/AutoGVP/02-annotate_variants_custom_input.R
@@ -345,7 +345,9 @@ combined_tab_with_vcf_intervar <- autopvs1_results %>%
       criterion == "IC5") & evidencePVS1 == 1, 0, as.double(evidencePVS1)),
 
     ## adjust variables based on given rules described in README
-    final_call = ifelse((evidencePVS1 == 1) & (evidencePVS1 == 1 &
+    final_call = ifelse(intervar_adjusted == "No", 
+                        sub(".*InterVar: ", "", sub("\\ P.*", "", `InterVar: InterVar and Evidence`)),
+    ifelse((evidencePVS1 == 1) & (evidencePVS1 == 1 &
       ((evidencePS >= 1) |
         (evidencePM >= 2) |
         (evidencePM == 1 & evidencePP == 1) |
@@ -410,6 +412,7 @@ combined_tab_with_vcf_intervar <- autopvs1_results %>%
     )
     )
     )
+  )
   )
 
 ## merge tables together (clinvar and intervar) and write to file


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

### Purpose/implementation Section

#### What feature is being added or bug is being addressed?

Closes #177. This PR modifies `annotate_variants_*_input.R` so that, when calls are made with intervar and `PVS1 == 0` / `intervar_adjusted == "No"`, the original call from `InterVar: InterVar and Evidence` column of intervar file is taken as `final_call`

#### What was your approach?

see above 

#### What GitHub issue does your pull request address?

#177 

### Directions for reviewers. Tell potential reviewers what kind of feedback you are soliciting.


#### Which areas should receive a particularly close look?

@rebkau can you run this on the sample we've been looking at (BS_XM3ER1N6), and confirm that the discrepancies have been resolved? 

#### Is there anything that you want to discuss further?

No

