### PR TITLE
Add AD columns to output

### DIFF
--- a/AutoGVP/04-filter_gene_annotations.R
+++ b/AutoGVP/04-filter_gene_annotations.R
@@ -122,7 +122,8 @@ autogvp <- read_tsv(input_autogvp_file,
 # Parse Sample column, if present
 if ("Sample" %in% names(autogvp)) {
   autogvp <- autogvp %>%
-    tidyr::separate_wider_delim(Sample, delim = ":", names = c("GT", "AD", "DP", "GQ"), too_many = "drop")
+    tidyr::separate_wider_delim(Sample, delim = ":", names = c("GT", "AD", "DP", "GQ"), too_many = "drop") %>%
+    tidyr::separate_wider_delim(AD, delim = ",", names = c("AD_ref", "AD_alt"), too_many = "drop")
 }
 
 # Merge `autogvp` and `vcf_final`

--- a/AutoGVP/input/output_colnames.tsv
+++ b/AutoGVP/input/output_colnames.tsv
@@ -34,6 +34,8 @@ evidenceBS	BS_autogvp	F
 evidenceBP	BP_autogvp	F
 intervar_adjusted	intervar_adjusted	F
 AC	AC	F
+AD_ref	AD_ref	F
+AD_alt	AD_alt	F
 AF	AF	F
 DP	DP	F
 ALLELEID	ALLELEID	F


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

### Purpose/implementation Section

#### What feature is being added or bug is being addressed?

Closes #179. Added columns `AD_ref` and `AD_alt` to full AutoGVP output

#### What was your approach?

Split VCF `FORMAT/AD` by `,` to generate unique columns for ref and alt counts

#### What GitHub issue does your pull request address?

#179 

### Directions for reviewers. Tell potential reviewers what kind of feedback you are soliciting.


#### Which areas should receive a particularly close look?

Please run on cavatica test files and ensure `AD_ref` and `AD_alt` are present in full output. 

```
bash run_autogvp.sh --workflow="cavatica" \
--vcf=input/test_pbta.single.vqsr.filtered.vep_105.vcf \
--filter_criteria='FORMAT/DP>=10 (FORMAT/AD[0:1-])/(FORMAT/DP)>=0.2 (gnomad_3_1_1_AF_non_cancer<0.001|gnomad_3_1_1_AF_non_cancer=".")' \
--intervar=input/test_pbta.hg38_multianno.txt.intervar \
--multianno=input/test_pbta.hg38_multianno.txt \
--autopvs1=input/test_pbta.autopvs1.tsv \
--outdir=../results \
--out="test_pbta"
```

#### Is there anything that you want to discuss further?

No

#### Documentation Checklist

<!-- Please review and specify if it isn't applicable -->

- [X] The function has examples to showcase the usage 

