### PR TITLE
Update wrapper script conditionals and base directory

### DIFF
--- a/scripts/02-annotate_variants_CAVATICA_input.R
+++ b/scripts/02-annotate_variants_CAVATICA_input.R
@@ -23,12 +23,6 @@ suppressPackageStartupMessages({
 # Get `magrittr` pipe
 `%>%` <- dplyr::`%>%`
 
-## set up directories
-root_dir <- rprojroot::find_root(rprojroot::has_dir(".git"))
-analysis_dir <- file.path(root_dir, "AutoGVP")
-input_dir <- file.path(analysis_dir, "input")
-
-
 # parse parameters
 option_list <- list(
   make_option(c("--vcf"),

--- a/scripts/02-annotate_variants_custom_input.R
+++ b/scripts/02-annotate_variants_custom_input.R
@@ -26,12 +26,6 @@ suppressPackageStartupMessages({
 # Get `magrittr` pipe
 `%>%` <- dplyr::`%>%`
 
-## set up directories
-root_dir <- rprojroot::find_root(rprojroot::has_dir(".git"))
-analysis_dir <- file.path(root_dir, "AutoGVP")
-input_dir <- file.path(analysis_dir, "input")
-
-
 # parse parameters
 option_list <- list(
   make_option(c("--vcf"),

--- a/scripts/04-filter_gene_annotations.R
+++ b/scripts/04-filter_gene_annotations.R
@@ -24,8 +24,8 @@ suppressPackageStartupMessages({
 `%>%` <- dplyr::`%>%`
 
 # set up directories
-root_dir <- rprojroot::find_root(rprojroot::has_dir(".git"))
-input_dir <- file.path(root_dir, "data")
+# root_dir <- rprojroot::find_root(rprojroot::has_dir(".git"))
+# input_dir <- file.path(root_dir, "data")
 
 
 # parse parameters
@@ -43,8 +43,13 @@ option_list <- list(
     help = "output name"
   ),
   make_option(c("--outdir"),
-    type = "character", default = "../results",
+    type = "character", default = "results",
     help = "output directory"
+  )
+  ,
+  make_option(c("--colnames"),
+              type = "character", default = "data/output_colnames.tsv",
+              help = "file listing output colnames"
   )
 )
 
@@ -55,6 +60,7 @@ input_vcf_file <- opt$vcf
 input_autogvp_file <- opt$autogvp
 output_name <- opt$output
 results_dir <- opt$outdir
+output_colnames_file <- opt$colnames
 
 # create results directory if it does not exist
 if (!dir.exists(results_dir)) {
@@ -188,9 +194,9 @@ merged_df <- merged_df %>%
   select(-any_of(c("ID", "avsnp147", "Existing_variation")))
 
 # read in output file column names tsv
-colnames <- read_tsv(file.path(input_dir, "output_colnames.tsv"),
-  show_col_types = FALSE
-)
+colnames <- read_tsv(output_colnames_file,
+                     show_col_types = FALSE
+                     )
 
 # Subset and reorder output columns based on inclusion and order in `colnames`
 merged_df <- merged_df %>%

--- a/scripts/04-filter_gene_annotations.R
+++ b/scripts/04-filter_gene_annotations.R
@@ -45,11 +45,10 @@ option_list <- list(
   make_option(c("--outdir"),
     type = "character", default = "results",
     help = "output directory"
-  )
-  ,
+  ),
   make_option(c("--colnames"),
-              type = "character", default = "data/output_colnames.tsv",
-              help = "file listing output colnames"
+    type = "character", default = "data/output_colnames.tsv",
+    help = "file listing output colnames"
   )
 )
 
@@ -195,8 +194,8 @@ merged_df <- merged_df %>%
 
 # read in output file column names tsv
 colnames <- read_tsv(output_colnames_file,
-                     show_col_types = FALSE
-                     )
+  show_col_types = FALSE
+)
 
 # Subset and reorder output columns based on inclusion and order in `colnames`
 merged_df <- merged_df %>%

--- a/scripts/select-clinVar-submissions.R
+++ b/scripts/select-clinVar-submissions.R
@@ -32,8 +32,8 @@ option_list <- list(
     help = "specific submission summary file (format: submission_summary.txt.gz)"
   ),
   make_option(c("--outdir"),
-              type = "character",
-              help = "output directory"
+    type = "character",
+    help = "output directory"
   )
 )
 

--- a/scripts/select-clinVar-submissions.R
+++ b/scripts/select-clinVar-submissions.R
@@ -21,11 +21,6 @@ suppressPackageStartupMessages({
 # Get `magrittr` pipe
 `%>%` <- dplyr::`%>%`
 
-## set up directories
-root_dir <- rprojroot::find_root(rprojroot::has_dir(".git"))
-input_dir <- file.path(root_dir, "data")
-
-
 # parse parameters
 option_list <- list(
   make_option(c("--variant_summary"),
@@ -35,6 +30,10 @@ option_list <- list(
   make_option(c("--submission_summary"),
     type = "character",
     help = "specific submission summary file (format: submission_summary.txt.gz)"
+  ),
+  make_option(c("--outdir"),
+              type = "character",
+              help = "output directory"
   )
 )
 
@@ -43,6 +42,7 @@ opt <- parse_args(OptionParser(option_list = option_list))
 ## get input files from parameters (reqd)
 input_submission_file <- opt$submission_summary
 input_variant_summary <- opt$variant_summary
+results_dir <- opt$outdir
 
 
 ## load variant summary file, which reports latest clinVar consensus calls for each variant
@@ -180,5 +180,5 @@ submission_final_df <- variants_no_conflicts %>%
 
 write_tsv(
   submission_final_df,
-  file.path(input_dir, "ClinVar-selected-submissions.tsv")
+  file.path(results_dir, "ClinVar-selected-submissions.tsv")
 )


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

### Purpose/implementation Section

#### What feature is being added or bug is being addressed?

Closes #182. This PR adds conditionals to ensure that all necessary ClinVar files are downloaded prior to running AutoGVP. A base directory was also defined and file paths were adjusted such that `run_autogvp.sh` can now be run from any directory. 

#### What was your approach?

- Added two conditional statements to `run_autogvp.sh`. The first downloads `variant_summary.txt.gz` and `submission_summary.txt.gz` from ClinVar database if they are not already downloaded, and the second runs `select-clinVar-submissions.R` if `ClinVar-selected-submissions.tsv` is not present. 

- Added a `BASEDIR` variable that is set to the root directory of the repo

#### What GitHub issue does your pull request address?

#182 

### Directions for reviewers. Tell potential reviewers what kind of feedback you are soliciting.


#### Which areas should receive a particularly close look?

To check that input files are downloaded when they are not present, please remove files `variant_summary.txt.gz`, `submission_summary.txt.gz`, and `ClinVar-selected-submissions.tsv` from working directory, and then run autogvp from root directory: 

```
bash run_autogvp.sh --workflow="cavatica" \
--vcf=data/test_pbta.single.vqsr.filtered.vep_105.vcf \
--filter_criteria='FORMAT/DP>=10 (FORMAT/AD[0:1-])/(FORMAT/DP)>=0.2 (gnomad_3_1_1_AF_non_cancer<0.001|gnomad_3_1_1_AF_non_cancer=".")' \
--intervar=data/test_pbta.hg38_multianno.txt.intervar \
--multianno=data/test_pbta.hg38_multianno.txt \
--autopvs1=data/test_pbta.autopvs1.tsv \
--outdir=results \
--out="test_pbta"
```

#### Is there anything that you want to discuss further?

This can also be tested to run from different directories, but the input file paths in the above command would need to be changed accordingly. 

#### Documentation Checklist

<!-- Please review and specify if it isn't applicable -->

- [X] The function has examples to showcase the usage 

