### PR TITLE
Rjcorb/194 fix select submission bug

### DIFF
--- a/scripts/select-clinVar-submissions.R
+++ b/scripts/select-clinVar-submissions.R
@@ -146,7 +146,7 @@ if (!is.null(conceptID_file)) {
     pull(VariationID)
 
   # add variants with one submission to variants_no_conflicts
-  variants_no_conflicts <- submission_merged_df %>%
+  variants_no_conflicts <- variants_with_conceptIDs %>%
     filter(VariationID %in% variants_no_conflicts_conceptID) %>%
     dplyr::mutate(ReviewStatus_var = glue::glue("{ReviewStatus_var}, single submission associated with conceptIDs")) %>%
     bind_rows(variants_no_conflicts)


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

### Purpose/implementation Section

#### What feature is being added or bug is being addressed?

Closes #194. This PR fixes a bug that was causing incorrect submissions to be selected for conflicting variants, in cases where only a single submission was associated with a provided conceptID. 

#### What was your approach?

After Variation IDs that only have one submission associated with a conceptID are identified, these VariationIDs are now being pulled from a df with ONLY ConceptID-associated submissions, rather than a df with all submissions. 

#### What GitHub issue does your pull request address?

#194 

### Directions for reviewers. Tell potential reviewers what kind of feedback you are soliciting.


#### Which areas should receive a particularly close look?

Please ensure that the updated code logic makes sense and run script from root: 

`Rscript scripts/select-clinVar-submissions.R --variant_summary data/variant_summary.txt.gz --submission_summary data/submission_summary.txt.gz --conceptID_list data/clinvar_cpg_concept_ids.txt --conflict_res "latest" --outdir results
`
#### Is there anything that you want to discuss further?

No

#### Documentation Checklist

<!-- Please review and specify if it isn't applicable -->

- [X] The function has examples to showcase the usage 


