### PR TITLE
Update cavatica workflow to allow for input of external clinvar vcf

### DIFF
--- a/run_autogvp.sh
+++ b/run_autogvp.sh
@@ -180,16 +180,32 @@ intervar_input=$out_dir/${out_file}_intervar_filtered.txt
 echo "Running AutoGVP..."
 
 # Run appropriate Rscript based on workflow source (Cavatica vs. custom)
-if [[ "$workflow" = "cavatica" ]];then
+if [[ "$workflow" = "cavatica" ]] ; then
 
-  # Run AutoGVP from Cavatica workflow
-  Rscript $BASEDIR/scripts/02-annotate_variants_CAVATICA_input.R --vcf $autogvp_input \
-  --multianno $multianno_input \
-  --intervar $intervar_input \
-  --autopvs1 $autopvs1_input \
-  --output $out_file \
-  --outdir $out_dir \
-  --variant_summary $selected_submissions
+  if [[ -f $clinvar_file ]] ; then
+
+    # Run AutoGVP from Cavatica workflow with provided clinvar vcf
+    Rscript $BASEDIR/scripts/02-annotate_variants_CAVATICA_input.R --vcf $autogvp_input \
+    --clinvar $clinvar_file \
+    --multianno $multianno_input \
+    --intervar $intervar_input \
+    --autopvs1 $autopvs1_input \
+    --output $out_file \
+    --outdir $out_dir \
+    --variant_summary $selected_submissions
+    
+    else
+    
+      # Run AutoGVP from Cavatica workflow with clinvar annotation in sample vcf
+    Rscript $BASEDIR/scripts/02-annotate_variants_CAVATICA_input.R --vcf $autogvp_input \
+    --multianno $multianno_input \
+    --intervar $intervar_input \
+    --autopvs1 $autopvs1_input \
+    --output $out_file \
+    --outdir $out_dir \
+    --variant_summary $selected_submissions
+    
+  fi
   
   autogvp_output=${out_dir}/${out_file}".cavatica_input.annotations_report.abridged.tsv"
 

--- a/scripts/02-annotate_variants_CAVATICA_input.R
+++ b/scripts/02-annotate_variants_CAVATICA_input.R
@@ -61,7 +61,7 @@ option_list <- list(
 
 opt <- parse_args(OptionParser(option_list = option_list))
 
-## get input files from parameters (reqd)
+## get input files from parameters (read)
 input_vcf_file <- opt$vcf
 input_intervar_file <- opt$intervar
 input_autopvs1_file <- opt$autopvs1

--- a/scripts/02-annotate_variants_CAVATICA_input.R
+++ b/scripts/02-annotate_variants_CAVATICA_input.R
@@ -112,7 +112,6 @@ vcf_df <- vroom(input_vcf_file, comment = "#", delim = "\t", col_names = c("CHRO
   )
 
 if (!is.null(input_clinVar_file)) {
-  
   ## add clinvar table to this (INFO)
   clinvar_anno_vcf_df <- vroom(input_clinVar_file, comment = "#", delim = "\t", col_names = c("CHROM", "POS", "ID", "REF", "ALT", "QUAL", "FILTER", "INFO"), trim_ws = TRUE, show_col_types = FALSE) %>%
     # add vcf id column
@@ -133,9 +132,7 @@ if (!is.null(input_clinVar_file)) {
       ## extract the calls and put in own column
       final_call_clinvar = str_match(INFO, "CLNSIG\\=(\\w+)([\\|\\/]\\w+)*\\;")[, 2]
     )
-  
 } else {
-  
   ## add column "vcf_id" to clinVar results in order to cross-reference with intervar and autopvs1 table
   clinvar_anno_vcf_df <- vcf_df %>%
     dplyr::mutate(
@@ -152,32 +149,31 @@ if (!is.null(input_clinVar_file)) {
       ## extract the calls and put in own column
       final_call_clinvar = str_match(INFO, "CLNSIG\\=(\\w+)([\\|\\/]\\w+)*\\;")[, 2]
     )
-  
 }
 
 # ## get latest calls from variant and submission summary files
 # variant_summary_df <- vroom(input_variant_summary, show_col_types = FALSE) %>%
 #   filter(vcf_id %in% clinvar_anno_vcf_df$vcf_id) %>%
 #   dplyr::select(-GeneSymbol)
-# 
+#
 # ## filter only those variants that need consensus call and find  call in submission table
 # entries_for_cc <- filter(clinvar_anno_vcf_df, Stars == "1NR", final_call_clinvar != "Benign", final_call_clinvar != "Pathogenic", final_call_clinvar != "Likely_benign", final_call_clinvar != "Likely_pathogenic", final_call_clinvar != "Uncertain_significance")
-# 
+#
 # entries_for_cc_in_submission <- inner_join(variant_summary_df, entries_for_cc, by = "vcf_id") %>%
 #   dplyr::mutate(final_call_clinvar = ClinicalSignificance) %>%
 #   dplyr::select(vcf_id, ClinicalSignificance, final_call_clinvar, Stars)
-# 
+#
 # ## one Star cases that are “criteria_provided,_single_submitter” that do NOT have the B, LB, P, LP, VUS call must also go to intervar
 # ## modified: any cases that do NOT have the B, LB, P, LP, VUS call must also go to intervar
 # additional_intervar_cases <- filter(clinvar_anno_vcf_df, final_call_clinvar != "Benign", final_call_clinvar != "Pathogenic", final_call_clinvar != "Likely_benign", final_call_clinvar != "Likely_pathogenic", final_call_clinvar != "Uncertain_significance") %>%
 #   anti_join(entries_for_cc_in_submission, by = "vcf_id")
-# 
-# 
+#
+#
 # ## filter only those variant entries that need an InterVar run (No Star) and add the additional intervar cases from above
 # entries_for_intervar <- filter(clinvar_anno_vcf_df, Stars == "0" | is.na(Stars), na.rm = TRUE) %>%
 #   bind_rows((additional_intervar_cases)) %>%
 #   distinct()
-# 
+#
 # ## get vcf ids that need intervar run
 # vcf_to_run_intervar <- entries_for_intervar$vcf_id
 
@@ -208,13 +204,11 @@ additional_intervar_cases <- filter(clinvar_anno_vcf_df, final_call_clinvar != "
   anti_join(clinvar_anti_join_vcf_df, by = "vcf_id")
 
 if (nrow(clinvar_anti_join_vcf_df) > 0) {
-
   clinvar_anti_join_vcf_df <- clinvar_anti_join_vcf_df %>%
     mutate(
       QUAL = as.character(QUAL),
-    #  POS = as.double(POS)
+      #  POS = as.double(POS)
     )
-  
 }
 
 ## filter only those variant entries that need an InterVar run (No Star) and add the additional intervar cases from above
@@ -475,11 +469,14 @@ master_tab <- full_join(master_tab, entries_for_cc_in_submission, by = "vcf_id")
   ) %>%
   dplyr::select(
     -any_of(
-      c("final_call_clinvar.x", "final_call_clinvar.y",
-      "Stars.x", "Stars.y",
-      "Intervar_evidence.x", "Intervar_evidence.y",
-      "INFO", "ClinicalSignificance.x", "ClinicalSignificance.y")
-  ))
+      c(
+        "final_call_clinvar.x", "final_call_clinvar.y",
+        "Stars.x", "Stars.y",
+        "Intervar_evidence.x", "Intervar_evidence.y",
+        "INFO", "ClinicalSignificance.x", "ClinicalSignificance.y"
+      )
+    )
+  )
 
 ## address ambiguous calls (non L/LB/P/LP/VUS) by taking the InterVar final call
 master_tab <- address_ambiguous_calls(master_tab)
@@ -508,9 +505,11 @@ master_tab <- master_tab %>%
   )) %>%
   dplyr::mutate(sample_id = output_name) %>%
   dplyr::relocate(
-    any_of(c("sample_id", "CHROM", "START", "POS", "ID", "REF", "ALT",
-           "final_call", "Reasoning_for_call",
-           "Stars", "ClinVar_ClinicalSignificance", "Intervar_evidence"))
+    any_of(c(
+      "sample_id", "CHROM", "START", "POS", "ID", "REF", "ALT",
+      "final_call", "Reasoning_for_call",
+      "Stars", "ClinVar_ClinicalSignificance", "Intervar_evidence"
+    ))
   )
 
 # write out to file

--- a/scripts/02-annotate_variants_CAVATICA_input.R
+++ b/scripts/02-annotate_variants_CAVATICA_input.R
@@ -62,11 +62,11 @@ option_list <- list(
 opt <- parse_args(OptionParser(option_list = option_list))
 
 ## get input files from parameters (reqd)
-input_clinVar_file <- opt$vcf
+input_vcf_file <- opt$vcf
 input_intervar_file <- opt$intervar
 input_autopvs1_file <- opt$autopvs1
 input_multianno_file <- opt$multianno
-clinvar_ver <- opt$clinvar
+input_clinVar_file <- opt$clinvar
 sample_name <- opt$output
 input_variant_summary <- opt$variant_summary
 summary_level <- opt$summary_level_vcf
@@ -105,30 +105,93 @@ address_ambiguous_calls <- function(results_tab_abridged) { ## address ambiguous
 }
 
 ## retrieve and store clinVar input file into table
-clinvar_anno_vcf_df <- vroom(input_clinVar_file, comment = "#", delim = "\t", col_names = c("CHROM", "START", "ID", "REF", "ALT", "QUAL", "FILTER", "INFO", "FORMAT", "Sample"), show_col_types = FALSE)
-
-## add column "vcf_id" to clinVar results in order to cross-reference with intervar and autopvs1 table
-clinvar_anno_vcf_df <- clinvar_anno_vcf_df %>%
+vcf_df <- vroom(input_vcf_file, comment = "#", delim = "\t", col_names = c("CHROM", "START", "ID", "REF", "ALT", "QUAL", "FILTER", "INFO", "FORMAT", "Sample"), show_col_types = FALSE) %>%
   dplyr::mutate(
     vcf_id = str_remove_all(paste(CHROM, "-", START, "-", REF, "-", ALT), " "),
-    vcf_id = str_replace(vcf_id, "chr", ""),
-    # add star annotations to clinVar results table based on filters // ## default version
-    Stars = case_when(
-      str_detect(INFO, "CLNREVSTAT\\=criteria_provided,_single_submitter") ~ "1",
-      str_detect(INFO, "CLNREVSTAT\\=criteria_provided,_multiple_submitters") ~ "2",
-      str_detect(INFO, "CLNREVSTAT\\=reviewed_by_expert_panel") ~ "3",
-      str_detect(INFO, "CLNREVSTAT\\=practice_guideline") ~ "4",
-      str_detect(INFO, "CLNREVSTAT\\=criteria_provided,_conflicting_interpretations") ~ "1NR",
-      str_detect(INFO, "no_assertion|no_interpretation") ~ "0",
-      TRUE ~ NA_character_
-    ),
-    ## extract the calls and put in own column
-    final_call_clinvar = str_match(INFO, "CLNSIG\\=(\\w+)([\\|\\/]\\w+)*\\;")[, 2]
+    vcf_id = str_replace(vcf_id, "chr", "")
   )
+
+if (!is.null(input_clinVar_file)) {
+  
+  ## add clinvar table to this (INFO)
+  clinvar_anno_vcf_df <- vroom(input_clinVar_file, comment = "#", delim = "\t", col_names = c("CHROM", "POS", "ID", "REF", "ALT", "QUAL", "FILTER", "INFO"), trim_ws = TRUE, show_col_types = FALSE) %>%
+    # add vcf id column
+    mutate(vcf_id = str_remove_all(paste(CHROM, "-", POS, "-", REF, "-", ALT), " ")) %>%
+    semi_join(vcf_df, by = "vcf_id") %>%
+    dplyr::mutate(
+      vcf_id = str_replace_all(vcf_id, "chr", ""),
+      # add star annotations to clinVar results table based on filters // ## default version
+      Stars = case_when(
+        str_detect(INFO, "CLNREVSTAT\\=criteria_provided,_single_submitter") ~ "1",
+        str_detect(INFO, "CLNREVSTAT\\=criteria_provided,_multiple_submitters") ~ "2",
+        str_detect(INFO, "CLNREVSTAT\\=reviewed_by_expert_panel") ~ "3",
+        str_detect(INFO, "CLNREVSTAT\\=practice_guideline") ~ "4",
+        str_detect(INFO, "CLNREVSTAT\\=criteria_provided,_conflicting_interpretations") ~ "1NR",
+        str_detect(INFO, "no_assertion|no_interpretation") ~ "0",
+        TRUE ~ NA_character_
+      ),
+      ## extract the calls and put in own column
+      final_call_clinvar = str_match(INFO, "CLNSIG\\=(\\w+)([\\|\\/]\\w+)*\\;")[, 2]
+    )
+  
+} else {
+  
+  ## add column "vcf_id" to clinVar results in order to cross-reference with intervar and autopvs1 table
+  clinvar_anno_vcf_df <- vcf_df %>%
+    dplyr::mutate(
+      # add star annotations to clinVar results table based on filters // ## default version
+      Stars = case_when(
+        str_detect(INFO, "CLNREVSTAT\\=criteria_provided,_single_submitter") ~ "1",
+        str_detect(INFO, "CLNREVSTAT\\=criteria_provided,_multiple_submitters") ~ "2",
+        str_detect(INFO, "CLNREVSTAT\\=reviewed_by_expert_panel") ~ "3",
+        str_detect(INFO, "CLNREVSTAT\\=practice_guideline") ~ "4",
+        str_detect(INFO, "CLNREVSTAT\\=criteria_provided,_conflicting_interpretations") ~ "1NR",
+        str_detect(INFO, "no_assertion|no_interpretation") ~ "0",
+        TRUE ~ NA_character_
+      ),
+      ## extract the calls and put in own column
+      final_call_clinvar = str_match(INFO, "CLNSIG\\=(\\w+)([\\|\\/]\\w+)*\\;")[, 2]
+    )
+  
+}
+
+# ## get latest calls from variant and submission summary files
+# variant_summary_df <- vroom(input_variant_summary, show_col_types = FALSE) %>%
+#   filter(vcf_id %in% clinvar_anno_vcf_df$vcf_id) %>%
+#   dplyr::select(-GeneSymbol)
+# 
+# ## filter only those variants that need consensus call and find  call in submission table
+# entries_for_cc <- filter(clinvar_anno_vcf_df, Stars == "1NR", final_call_clinvar != "Benign", final_call_clinvar != "Pathogenic", final_call_clinvar != "Likely_benign", final_call_clinvar != "Likely_pathogenic", final_call_clinvar != "Uncertain_significance")
+# 
+# entries_for_cc_in_submission <- inner_join(variant_summary_df, entries_for_cc, by = "vcf_id") %>%
+#   dplyr::mutate(final_call_clinvar = ClinicalSignificance) %>%
+#   dplyr::select(vcf_id, ClinicalSignificance, final_call_clinvar, Stars)
+# 
+# ## one Star cases that are “criteria_provided,_single_submitter” that do NOT have the B, LB, P, LP, VUS call must also go to intervar
+# ## modified: any cases that do NOT have the B, LB, P, LP, VUS call must also go to intervar
+# additional_intervar_cases <- filter(clinvar_anno_vcf_df, final_call_clinvar != "Benign", final_call_clinvar != "Pathogenic", final_call_clinvar != "Likely_benign", final_call_clinvar != "Likely_pathogenic", final_call_clinvar != "Uncertain_significance") %>%
+#   anti_join(entries_for_cc_in_submission, by = "vcf_id")
+# 
+# 
+# ## filter only those variant entries that need an InterVar run (No Star) and add the additional intervar cases from above
+# entries_for_intervar <- filter(clinvar_anno_vcf_df, Stars == "0" | is.na(Stars), na.rm = TRUE) %>%
+#   bind_rows((additional_intervar_cases)) %>%
+#   distinct()
+# 
+# ## get vcf ids that need intervar run
+# vcf_to_run_intervar <- entries_for_intervar$vcf_id
+
+## store variants without clinvar info
+clinvar_anti_join_vcf_df <- anti_join(vcf_df, clinvar_anno_vcf_df, by = "vcf_id") %>%
+  dplyr::mutate(
+    vcf_id = str_replace_all(vcf_id, "chr", ""),
+    CHROM = str_replace_all(CHROM, "chr", "")
+  ) %>%
+  dplyr::rename(rs_id = ID)
 
 ## get latest calls from variant and submission summary files
 variant_summary_df <- vroom(input_variant_summary, show_col_types = FALSE) %>%
-  filter(vcf_id %in% clinvar_anno_vcf_df$vcf_id) %>%
+  filter(vcf_id %in% vcf_df$vcf_id) %>%
   dplyr::select(-GeneSymbol)
 
 ## filter only those variants that need consensus call and find  call in submission table
@@ -141,15 +204,25 @@ entries_for_cc_in_submission <- inner_join(variant_summary_df, entries_for_cc, b
 ## one Star cases that are “criteria_provided,_single_submitter” that do NOT have the B, LB, P, LP, VUS call must also go to intervar
 ## modified: any cases that do NOT have the B, LB, P, LP, VUS call must also go to intervar
 additional_intervar_cases <- filter(clinvar_anno_vcf_df, final_call_clinvar != "Benign", final_call_clinvar != "Pathogenic", final_call_clinvar != "Likely_benign", final_call_clinvar != "Likely_pathogenic", final_call_clinvar != "Uncertain_significance") %>%
-  anti_join(entries_for_cc_in_submission, by = "vcf_id")
+  anti_join(entries_for_cc_in_submission, by = "vcf_id") %>%
+  anti_join(clinvar_anti_join_vcf_df, by = "vcf_id")
 
+if (nrow(clinvar_anti_join_vcf_df) < 0) {
+
+  clinvar_anti_join_vcf_df <- clinvar_anti_join_vcf_df %>%
+    mutate(
+      QUAL = as.character(QUAL),
+      POS = as.double(POS)
+    )
+  
+}
 
 ## filter only those variant entries that need an InterVar run (No Star) and add the additional intervar cases from above
 entries_for_intervar <- filter(clinvar_anno_vcf_df, Stars == "0" | is.na(Stars), na.rm = TRUE) %>%
   bind_rows((additional_intervar_cases)) %>%
+  bind_rows(clinvar_anti_join_vcf_df) %>%
   distinct()
 
-## get vcf ids that need intervar run
 vcf_to_run_intervar <- entries_for_intervar$vcf_id
 
 ## get multianno file to add  correct vcf_id in intervar table


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

### Purpose/implementation Section

#### What feature is being added or bug is being addressed?

Closes #211. This PR updates AutoGVP cavatica workflow to allow for input of and annotation with an external clinvar vcf, to replace any clinvar annotation in sample VCFs. 


#### What was your approach?

- Updated `run_autogvp.sh` to allow for clinvar vcf argument when running `02-annotate_variants_CAVATICA_input.R`.
-  Updated `02-annotate_variants_CAVATICA_input.R` to include conditional statements dependent on whether ClinVar calls should be made with sample VCF annotations vs external ClinVar vcf. 

#### What GitHub issue does your pull request address?

#211 

### Directions for reviewers. Tell potential reviewers what kind of feedback you are soliciting.


#### Which areas should receive a particularly close look?

Please review updated code. @jungkim2, can you determine if RMS calls are the same between cavatica and custom workflow when using the Oct 2023 clinvar vcf as input? 

#### Is there anything that you want to discuss further?

I have run the RMS dataset through the updated cavatica workflow WITHOUT external clinvar vcf, and results match those from the previous AutoGVP version. I have also run the dataset through the updated workflow WITH the Oct 2023 clinvar vcf as input, and there are ~1000 different calls that seem to be due to new ClinVar submissions since May 2022 (ClinVar version used by cavatica workflow by default). 


