### PR TITLE
fix submission file loading bug

### DIFF
--- a/scripts/select-clinVar-submissions.R
+++ b/scripts/select-clinVar-submissions.R
@@ -49,7 +49,7 @@ option_list <- list(
 
 opt <- parse_args(OptionParser(option_list = option_list))
 
-## get input files from parameters (reqd)
+## get input files from parameters (read)
 input_submission_file <- opt$submission_summary
 input_variant_summary <- opt$variant_summary
 results_dir <- opt$outdir
@@ -77,15 +77,24 @@ variant_summary_df <- vroom(input_variant_summary,
   dplyr::filter(!ReviewStatus %in% c("no assertion provided", "no assertion criteria provided"))
 
 # Load clinVar submission summary file, which reports all submissions for each clinVar variant
+
+# Open the file and read lines until a line without '#' is found
+con <- file(input_submission_file, "r")
+skip_lines <- 0
+while (grepl("^#", readLines(con, n = 1))) {
+  skip_lines <- skip_lines + 1
+}
+
+# Load submission file while skipping number of lines determined above
 submission_summary_df <- vroom(input_submission_file,
-  comment = "#", delim = "\t",
-  col_names = c(
-    "VariationID", "ClinicalSignificance", "DateLastEvaluated",
-    "Description", "SubmittedPhenotypeInfo", "ReportedPhenotypeInfo",
-    "ReviewStatus", "CollectionMethod", "OriginCounts", "Submitter",
-    "SCV", "SubmittedGeneSymbol", "ExplanationOfInterpretation"
-  ),
-  show_col_types = F
+                               skip = skip_lines, delim = "\t",
+                               col_names = c(
+                                 "VariationID", "ClinicalSignificance", "DateLastEvaluated",
+                                 "Description", "SubmittedPhenotypeInfo", "ReportedPhenotypeInfo",
+                                 "ReviewStatus", "CollectionMethod", "OriginCounts", "Submitter",
+                                 "SCV", "SubmittedGeneSymbol", "ExplanationOfInterpretation"
+                               ),
+                               show_col_types = F
 ) %>%
   # Redefine `DateLastEvaluated`
   dplyr::mutate(

--- a/scripts/select-clinVar-submissions.R
+++ b/scripts/select-clinVar-submissions.R
@@ -87,14 +87,14 @@ while (grepl("^#", readLines(con, n = 1))) {
 
 # Load submission file while skipping number of lines determined above
 submission_summary_df <- vroom(input_submission_file,
-                               skip = skip_lines, delim = "\t",
-                               col_names = c(
-                                 "VariationID", "ClinicalSignificance", "DateLastEvaluated",
-                                 "Description", "SubmittedPhenotypeInfo", "ReportedPhenotypeInfo",
-                                 "ReviewStatus", "CollectionMethod", "OriginCounts", "Submitter",
-                                 "SCV", "SubmittedGeneSymbol", "ExplanationOfInterpretation"
-                               ),
-                               show_col_types = F
+  skip = skip_lines, delim = "\t",
+  col_names = c(
+    "VariationID", "ClinicalSignificance", "DateLastEvaluated",
+    "Description", "SubmittedPhenotypeInfo", "ReportedPhenotypeInfo",
+    "ReviewStatus", "CollectionMethod", "OriginCounts", "Submitter",
+    "SCV", "SubmittedGeneSymbol", "ExplanationOfInterpretation"
+  ),
+  show_col_types = F
 ) %>%
   # Redefine `DateLastEvaluated`
   dplyr::mutate(


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

### Purpose/implementation Section

#### What feature is being added or bug is being addressed?

Closes #216. This PR addresses a bug in `select-ClinVar-submissions.R` script that was resulting in the contents of some rows being ignored. 

#### What was your approach?

I removed the `comment = "#"` argument from `vroom()` when reading in `submission_summary.txt.gz`. In its place, we determine the number of lines to skip using a `while()` statement that reads file lines until `#` is not found at start of line. This number is assigned to variable `skip_lines`, and is assigned as value of `skip` in `vroom()` function. 

#### What GitHub issue does your pull request address?

#216 

### Directions for reviewers. Tell potential reviewers what kind of feedback you are soliciting.


#### Which areas should receive a particularly close look?

Please review updated code and ensure script runs successfully: 

```
Rscript scripts/select-clinVar-submissions.R --variant_summary data/variant_summary.txt.gz --submission_summary data/submission_summary.txt.gz --outdir ../bug_fix --conceptID_list data/clinvar_all_disease_concept_ids.txt --conflict_res "latest"`
```

 I have tested the new function and it results in all rows of `submission_summary.txt.gz` being loaded in their entirety. This error was found because we were getting an incorrect resolution for variant `186251` (previously called LP), but it is now called VUS as expected. 

#### Is there anything that you want to discuss further?

No



