### PR TITLE
Add ClinVar origin columns to AutoGVP output

### DIFF
--- a/data/output_colnames.tsv
+++ b/data/output_colnames.tsv
@@ -59,6 +59,8 @@ CLNSIGCONF	clinvar_conflicting_significance	F
 CLNSIGINCL	clinvar_clinsig_variant	F
 CLNVC	clinvar_variant_type	F
 CLNVCSO	clinvar_sequence_ontology	F
+Origin	clinvar_origin
+OriginSimple	clinvar_origin_simple
 culprit	culprit	F
 ExcessHet	ExcessHet	F
 FS	FS	F

--- a/scripts/02-annotate_variants_CAVATICA_input.R
+++ b/scripts/02-annotate_variants_CAVATICA_input.R
@@ -151,32 +151,6 @@ if (!is.null(input_clinVar_file)) {
     )
 }
 
-# ## get latest calls from variant and submission summary files
-# variant_summary_df <- vroom(input_variant_summary, show_col_types = FALSE) %>%
-#   filter(vcf_id %in% clinvar_anno_vcf_df$vcf_id) %>%
-#   dplyr::select(-GeneSymbol)
-#
-# ## filter only those variants that need consensus call and find  call in submission table
-# entries_for_cc <- filter(clinvar_anno_vcf_df, Stars == "1NR", final_call_clinvar != "Benign", final_call_clinvar != "Pathogenic", final_call_clinvar != "Likely_benign", final_call_clinvar != "Likely_pathogenic", final_call_clinvar != "Uncertain_significance")
-#
-# entries_for_cc_in_submission <- inner_join(variant_summary_df, entries_for_cc, by = "vcf_id") %>%
-#   dplyr::mutate(final_call_clinvar = ClinicalSignificance) %>%
-#   dplyr::select(vcf_id, ClinicalSignificance, final_call_clinvar, Stars)
-#
-# ## one Star cases that are “criteria_provided,_single_submitter” that do NOT have the B, LB, P, LP, VUS call must also go to intervar
-# ## modified: any cases that do NOT have the B, LB, P, LP, VUS call must also go to intervar
-# additional_intervar_cases <- filter(clinvar_anno_vcf_df, final_call_clinvar != "Benign", final_call_clinvar != "Pathogenic", final_call_clinvar != "Likely_benign", final_call_clinvar != "Likely_pathogenic", final_call_clinvar != "Uncertain_significance") %>%
-#   anti_join(entries_for_cc_in_submission, by = "vcf_id")
-#
-#
-# ## filter only those variant entries that need an InterVar run (No Star) and add the additional intervar cases from above
-# entries_for_intervar <- filter(clinvar_anno_vcf_df, Stars == "0" | is.na(Stars), na.rm = TRUE) %>%
-#   bind_rows((additional_intervar_cases)) %>%
-#   distinct()
-#
-# ## get vcf ids that need intervar run
-# vcf_to_run_intervar <- entries_for_intervar$vcf_id
-
 ## store variants without clinvar info
 clinvar_anti_join_vcf_df <- anti_join(vcf_df, clinvar_anno_vcf_df, by = "vcf_id") %>%
   dplyr::mutate(
@@ -416,7 +390,7 @@ combined_tab_with_vcf_intervar <- autopvs1_results %>%
 ## merge tables together (clinvar and intervar) and write to file
 master_tab <- clinvar_anno_intervar_vcf_df %>%
   full_join(combined_tab_with_vcf_intervar[, grepl("vcf_id|intervar_adjusted|evidence|InterVar:|final_call_intervar", names(combined_tab_with_vcf_intervar))], by = "vcf_id") %>%
-  left_join(variant_summary_df[, c("vcf_id", "VariationID", "ClinicalSignificance", "ReviewStatus", "LastEvaluated", "clinvar_flag")], by = "vcf_id") %>%
+  left_join(variant_summary_df[, c("vcf_id", "VariationID", "ClinicalSignificance", "ReviewStatus", "LastEvaluated", "clinvar_flag", "Origin", "OriginSimple")], by = "vcf_id") %>%
   left_join(autopvs1_results, by = "vcf_id")
 
 

--- a/scripts/02-annotate_variants_custom_input.R
+++ b/scripts/02-annotate_variants_custom_input.R
@@ -375,7 +375,7 @@ combined_tab_with_vcf_intervar <- autopvs1_results %>%
 ## merge tables together (clinvar and intervar) and write to file
 master_tab <- clinvar_anno_intervar_vcf_df %>%
   full_join(combined_tab_with_vcf_intervar[, grepl("vcf_id|intervar_adjusted|evidence|InterVar:|final_call_intervar", names(combined_tab_with_vcf_intervar))], by = "vcf_id") %>%
-  left_join(variant_summary_df[, c("vcf_id", "VariationID", "ClinicalSignificance", "ReviewStatus", "LastEvaluated", "clinvar_flag")], by = "vcf_id") %>%
+  left_join(variant_summary_df[, c("vcf_id", "VariationID", "ClinicalSignificance", "ReviewStatus", "LastEvaluated", "clinvar_flag", "Origin", "OriginSimple")], by = "vcf_id") %>%
   left_join(autopvs1_results, by = "vcf_id")
 
 

--- a/scripts/select-clinVar-submissions.R
+++ b/scripts/select-clinVar-submissions.R
@@ -285,7 +285,8 @@ submission_final_df <- variants_no_conflicts %>%
     "VariationID", "ClinicalSignificance",
     "LastEvaluated", "Description", "SubmittedPhenotypeInfo",
     "ReportedPhenotypeInfo", "ReviewStatus",
-    "SubmittedGeneSymbol", "GeneSymbol", "vcf_id"
+    "SubmittedGeneSymbol", "GeneSymbol", "vcf_id",
+    "Origin", "OriginSimple"
   )))
 
 # extract all variants with conflicting interpretations


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

### Purpose/implementation Section

#### What feature is being added or bug is being addressed?

Closes #217. This PR updates AutoGVP scripts to include ClinVar `Origin` and `OriginSimple` columns to final autogvp output.


#### What was your approach?

- Updated `select-clinvar-submissions.R` scripts to save Origin columns to output file. 
- Update `02-annotate_variants*_input.R` R scripts to save origin columns to intermediate output. 
- Update `output_colnames.tsv` to include ClinVar origin columns to final full output. 

#### What GitHub issue does your pull request address?

#217 

### Directions for reviewers. Tell potential reviewers what kind of feedback you are soliciting.


#### Which areas should receive a particularly close look?

Please re-run select ClinVar submissions script from AutoGVP root directory: 

```
Rscript scripts/select-clinVar-submissions.R --variant_summary data/variant_summary.txt.gz --submission_summary data/submission_summary.txt.gz --outdir results --conceptID_list data/clinvar_all_disease_concept_ids.txt --conflict_res "latest"
```

The `ClinVar-selected-submissions.tsv` file should contain columns `Origin` and `OriginSimple`. 

Run test pbta sample through updated AutoGVP code to ensure origin columns are included in full output: 

```
bash run_autogvp.sh --workflow="cavatica" \
--vcf=data/test_pbta.single.vqsr.filtered.vep_105.vcf \
--filter_criteria='FORMAT/DP>=10 (FORMAT/AD[0:1-])/(FORMAT/DP)>=0.2 (gnomad_3_1_1_AF_non_cancer<0.001|gnomad_3_1_1_AF_non_cancer=".")' \
--intervar=data/test_pbta.hg38_multianno.txt.intervar \
--multianno=data/test_pbta.hg38_multianno.txt \
--autopvs1=data/test_pbta.autopvs1.tsv \
--selected_clinvar_submissions=results/ClinVar-selected-submissions.tsv \
--outdir=results \
--out="test_pbta_origin"
```


#### Is there anything that you want to discuss further?

As of Jan 29 2024, ClinVar is incorporating classification of somatic variants into its database. When new ClinVar variant and submission summary files are available, we will have to assess whether this will require further changes to AutoGVP. 

#### Documentation Checklist

<!-- Please review and specify if it isn't applicable -->

- [X] The function has examples to showcase the usage 

