### PR TITLE
Rjcorb/234 update variant ids col

### DIFF
--- a/data/output_colnames.tsv
+++ b/data/output_colnames.tsv
@@ -5,7 +5,7 @@ POS	start	T
 START	start	T
 REF	ref	T
 ALT	alt	T
-rsID	rs_id	T
+variantID	variant_ids	T
 SYMBOL	gene_symbol_vep	T
 Consequence	variant_classification_vep	T
 HGVSg	HGVSg	T
@@ -59,8 +59,8 @@ CLNSIGCONF	clinvar_conflicting_significance	F
 CLNSIGINCL	clinvar_clinsig_variant	F
 CLNVC	clinvar_variant_type	F
 CLNVCSO	clinvar_sequence_ontology	F
-Origin	clinvar_origin
-OriginSimple	clinvar_origin_simple
+Origin	clinvar_origin	
+OriginSimple	clinvar_origin_simple	
 culprit	culprit	F
 ExcessHet	ExcessHet	F
 FS	FS	F

--- a/scripts/04-filter_gene_annotations.R
+++ b/scripts/04-filter_gene_annotations.R
@@ -183,13 +183,14 @@ coacross <- function(...) {
 # Coalesce rsIDs across multiple columns, when present
 id_df <- merged_df %>%
   dplyr::select(any_of(c("ID", "avsnp147", "Existing_variation"))) %>%
-  # dplyr::mutate_all(funs(ifelse(grepl("rs", .), ., NA_character_))) %>%
   dplyr::mutate(across(everything(), ~ ifelse(grepl("rs", .x), .x, NA_character_))) %>%
-  dplyr::mutate(rsID = coacross())
+  dplyr::mutate(variantID = coacross()) %>%
+  dplyr::mutate(variantID = str_replace(variantID, "&", ";")) %>%
+  dplyr::mutate(variantID = str_replace_all(variantID, "~", ""))
 
 # Add coalesced rsID to merged_df, and remove other ID columns
 merged_df <- merged_df %>%
-  dplyr::mutate(rsID = id_df$rsID) %>%
+  dplyr::mutate(variantID = id_df$variantID) %>%
   select(-any_of(c("ID", "avsnp147", "Existing_variation")))
 
 # read in output file column names tsv

--- a/scripts/04-filter_gene_annotations.R
+++ b/scripts/04-filter_gene_annotations.R
@@ -194,18 +194,18 @@ split_and_unique <- function(string) {
 # Coalesce rsIDs across multiple columns, when present
 id_df <- merged_df %>%
   dplyr::select(any_of(c("ID", "avsnp147", "Existing_variation"))) %>%
-#  dplyr::mutate(across(everything(), ~ ifelse(grepl("rs", .x), .x, NA_character_))) %>%
-#  dplyr::mutate(variantID = coacross()) %>%
-#  dplyr::mutate(variantID = str_replace(variantID, "&", ";")) %>%
-#  dplyr::mutate(variantID = str_replace_all(variantID, "~", ""))
-#  dplyr::mutate(across(everything(), as.character)) %>%
+  #  dplyr::mutate(across(everything(), ~ ifelse(grepl("rs", .x), .x, NA_character_))) %>%
+  #  dplyr::mutate(variantID = coacross()) %>%
+  #  dplyr::mutate(variantID = str_replace(variantID, "&", ";")) %>%
+  #  dplyr::mutate(variantID = str_replace_all(variantID, "~", ""))
+  #  dplyr::mutate(across(everything(), as.character)) %>%
   dplyr::mutate(across(everything(), ~ ifelse(.x %in% c(".", NA_character_), "", .x))) %>%
   rowwise() %>%
   mutate(variantID = glue::glue(paste(c_across(everything()), collapse = ";"))) %>%
   ungroup() %>%
   dplyr::mutate(variantID = unlist(lapply(variantID, split_and_unique))) %>%
   dplyr::mutate(variantID = case_when(
-    variantID == "NA" ~ "", 
+    variantID == "NA" ~ "",
     TRUE ~ variantID
   )) %>%
   dplyr::mutate(variantID = str_replace_all(variantID, "~", ""))


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

### Purpose/implementation Section

#### What feature is being added or bug is being addressed?

Closes #234. This PR renames the `rs_id` column as `variant_ids` to reflect cases where multiple variant ID sources are listed. The `&` separator is also replaced with `;`

#### What was your approach?



#### What GitHub issue does your pull request address?

#234 

### Directions for reviewers. Tell potential reviewers what kind of feedback you are soliciting.


#### Which areas should receive a particularly close look?

Please run the custom test samples through AutoGVP , and confirm `variant_id` column is present and, when applicable, that variant ids are separated by `;`

```
bash run_autogvp.sh --workflow="custom" \
--vcf=data/test_VEP.vcf \
--clinvar=data/clinvar.vcf.gz \
--intervar=data/test_VEP.hg38_multianno.txt.intervar \
--multianno=data/test_VEP.vcf.hg38_multianno.txt \
--autopvs1=data/test_autopvs1.txt \
--outdir=results \
--out="test_custom"
```

#### Is there anything that you want to discuss further?

No
#### Documentation Checklist

<!-- Please review and specify if it isn't applicable -->

- [ ] The function has examples to showcase the usage 
- [ ] Added a vignette

