### PR TITLE
rm leading semicolon in variant_ids

### DIFF
--- a/scripts/04-filter_gene_annotations.R
+++ b/scripts/04-filter_gene_annotations.R
@@ -194,11 +194,6 @@ split_and_unique <- function(string) {
 # Coalesce rsIDs across multiple columns, when present
 id_df <- merged_df %>%
   dplyr::select(any_of(c("ID", "avsnp147", "Existing_variation"))) %>%
-  #  dplyr::mutate(across(everything(), ~ ifelse(grepl("rs", .x), .x, NA_character_))) %>%
-  #  dplyr::mutate(variantID = coacross()) %>%
-  #  dplyr::mutate(variantID = str_replace(variantID, "&", ";")) %>%
-  #  dplyr::mutate(variantID = str_replace_all(variantID, "~", ""))
-  #  dplyr::mutate(across(everything(), as.character)) %>%
   dplyr::mutate(across(everything(), ~ ifelse(.x %in% c(".", NA_character_), "", .x))) %>%
   rowwise() %>%
   mutate(variantID = glue::glue(paste(c_across(everything()), collapse = ";"))) %>%
@@ -208,7 +203,8 @@ id_df <- merged_df %>%
     variantID == "NA" ~ "",
     TRUE ~ variantID
   )) %>%
-  dplyr::mutate(variantID = str_replace_all(variantID, "~", ""))
+  dplyr::mutate(variantID = str_replace_all(variantID, "~", "")) %>%
+  dplyr::mutate(variantID = str_replace(variantID, "^;", ""))
 
 # Add coalesced rsID to merged_df, and remove other ID columns
 merged_df <- merged_df %>%


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

### Purpose/implementation Section

#### What feature is being added or bug is being addressed?

Closes #238. Simple fix to remove semicolons at the start of `variant_ids` column values (will occur in instances where no value in `raid`)

#### What was your approach?



#### What GitHub issue does your pull request address?



### Directions for reviewers. Tell potential reviewers what kind of feedback you are soliciting.


#### Which areas should receive a particularly close look?



#### Is there anything that you want to discuss further?


#### Documentation Checklist

<!-- Please review and specify if it isn't applicable -->

- [ ] The function has examples to showcase the usage 
- [ ] Added a vignette

