### PR TITLE
Update search criteria for clinvar conflicting variants

### DIFF
--- a/scripts/02-annotate_variants_CAVATICA_input.R
+++ b/scripts/02-annotate_variants_CAVATICA_input.R
@@ -126,7 +126,7 @@ if (!is.null(input_clinVar_file)) {
         str_detect(INFO, "CLNREVSTAT\\=reviewed_by_expert_panel") ~ "3",
         str_detect(INFO, "CLNREVSTAT\\=practice_guideline") ~ "4",
         str_detect(INFO, "CLNREVSTAT\\=criteria_provided,_conflicting_interpretations|CLNREVSTAT\\=criteria_provided,_conflicting_classifications") ~ "1NR",
-        str_detect(INFO, "no_assertion|no_interpretation") ~ "0",
+        str_detect(INFO, "no_assertion|no_interpretation|no_classification") ~ "0",
         TRUE ~ NA_character_
       ),
       ## extract the calls and put in own column
@@ -143,7 +143,7 @@ if (!is.null(input_clinVar_file)) {
         str_detect(INFO, "CLNREVSTAT\\=reviewed_by_expert_panel") ~ "3",
         str_detect(INFO, "CLNREVSTAT\\=practice_guideline") ~ "4",
         str_detect(INFO, "CLNREVSTAT\\=criteria_provided,_conflicting_interpretations|CLNREVSTAT\\=criteria_provided,_conflicting_classifications") ~ "1NR",
-        str_detect(INFO, "no_assertion|no_interpretation") ~ "0",
+        str_detect(INFO, "no_assertion|no_interpretation|no_classification") ~ "0",
         TRUE ~ NA_character_
       ),
       ## extract the calls and put in own column

--- a/scripts/02-annotate_variants_CAVATICA_input.R
+++ b/scripts/02-annotate_variants_CAVATICA_input.R
@@ -125,7 +125,7 @@ if (!is.null(input_clinVar_file)) {
         str_detect(INFO, "CLNREVSTAT\\=criteria_provided,_multiple_submitters") ~ "2",
         str_detect(INFO, "CLNREVSTAT\\=reviewed_by_expert_panel") ~ "3",
         str_detect(INFO, "CLNREVSTAT\\=practice_guideline") ~ "4",
-        str_detect(INFO, "CLNREVSTAT\\=criteria_provided,_conflicting_interpretations") ~ "1NR",
+        str_detect(INFO, "CLNREVSTAT\\=criteria_provided,_conflicting_interpretations|CLNREVSTAT\\=criteria_provided,_conflicting_classifications") ~ "1NR",
         str_detect(INFO, "no_assertion|no_interpretation") ~ "0",
         TRUE ~ NA_character_
       ),
@@ -142,7 +142,7 @@ if (!is.null(input_clinVar_file)) {
         str_detect(INFO, "CLNREVSTAT\\=criteria_provided,_multiple_submitters") ~ "2",
         str_detect(INFO, "CLNREVSTAT\\=reviewed_by_expert_panel") ~ "3",
         str_detect(INFO, "CLNREVSTAT\\=practice_guideline") ~ "4",
-        str_detect(INFO, "CLNREVSTAT\\=criteria_provided,_conflicting_interpretations") ~ "1NR",
+        str_detect(INFO, "CLNREVSTAT\\=criteria_provided,_conflicting_interpretations|CLNREVSTAT\\=criteria_provided,_conflicting_classifications") ~ "1NR",
         str_detect(INFO, "no_assertion|no_interpretation") ~ "0",
         TRUE ~ NA_character_
       ),

--- a/scripts/02-annotate_variants_custom_input.R
+++ b/scripts/02-annotate_variants_custom_input.R
@@ -132,7 +132,7 @@ clinvar_anno_vcf_df <- vroom(input_clinVar_file, comment = "#", delim = "\t", co
       str_detect(INFO, "CLNREVSTAT\\=reviewed_by_expert_panel") ~ "3",
       str_detect(INFO, "CLNREVSTAT\\=practice_guideline") ~ "4",
       str_detect(INFO, "CLNREVSTAT\\=criteria_provided,_conflicting_interpretations|CLNREVSTAT\\=criteria_provided,_conflicting_classifications") ~ "1NR",
-      str_detect(INFO, "no_assertion|no_interpretation") ~ "0",
+      str_detect(INFO, "no_assertion|no_interpretation|no_classification") ~ "0",
       TRUE ~ NA_character_
     ),
     ## extract the calls and put in own column

--- a/scripts/02-annotate_variants_custom_input.R
+++ b/scripts/02-annotate_variants_custom_input.R
@@ -131,7 +131,7 @@ clinvar_anno_vcf_df <- vroom(input_clinVar_file, comment = "#", delim = "\t", co
       str_detect(INFO, "CLNREVSTAT\\=criteria_provided,_multiple_submitters") ~ "2",
       str_detect(INFO, "CLNREVSTAT\\=reviewed_by_expert_panel") ~ "3",
       str_detect(INFO, "CLNREVSTAT\\=practice_guideline") ~ "4",
-      str_detect(INFO, "CLNREVSTAT\\=criteria_provided,_conflicting_interpretations") ~ "1NR",
+      str_detect(INFO, "CLNREVSTAT\\=criteria_provided,_conflicting_interpretations|CLNREVSTAT\\=criteria_provided,_conflicting_classifications") ~ "1NR",
       str_detect(INFO, "no_assertion|no_interpretation") ~ "0",
       TRUE ~ NA_character_
     ),

--- a/scripts/select-clinVar-submissions.R
+++ b/scripts/select-clinVar-submissions.R
@@ -295,8 +295,10 @@ submission_final_df <- variants_no_conflicts %>%
 
 # extract all variants with conflicting interpretations
 clinvar_conflicting <- variant_summary_df %>%
-  dplyr::filter(ReviewStatus %in% c("criteria provided, conflicting interpretations",
-                                    "criteria provided, conflicting classifications")) %>%
+  dplyr::filter(ReviewStatus %in% c(
+    "criteria provided, conflicting interpretations",
+    "criteria provided, conflicting classifications"
+  )) %>%
   pull(VariationID)
 
 # extract all variants with >= P/LP call

--- a/scripts/select-clinVar-submissions.R
+++ b/scripts/select-clinVar-submissions.R
@@ -75,8 +75,10 @@ variant_summary_df <- vroom(input_variant_summary,
       TRUE ~ LastEvaluated
     )
   ) %>%
-  dplyr::filter(!ReviewStatus %in% c("no assertion provided", "no assertion criteria provided",
-                                     "no classification for the individual variant", "no classification provided"))
+  dplyr::filter(!ReviewStatus %in% c(
+    "no assertion provided", "no assertion criteria provided",
+    "no classification for the individual variant", "no classification provided"
+  ))
 
 # Load clinVar submission summary file, which reports all submissions for each clinVar variant
 
@@ -107,8 +109,10 @@ submission_summary_df <- vroom(input_submission_file,
     VariationID = as.double(VariationID)
   ) %>%
   dplyr::filter(
-    !ReviewStatus %in% c("no assertion provided", "no assertion criteria provided",
-                         "no classification provided"),
+    !ReviewStatus %in% c(
+      "no assertion provided", "no assertion criteria provided",
+      "no classification provided"
+    ),
     ClinicalSignificance %in% c("Pathogenic", "Likely pathogenic", "Benign", "Likely benign", "Uncertain significance")
   )
 

--- a/scripts/select-clinVar-submissions.R
+++ b/scripts/select-clinVar-submissions.R
@@ -75,7 +75,8 @@ variant_summary_df <- vroom(input_variant_summary,
       TRUE ~ LastEvaluated
     )
   ) %>%
-  dplyr::filter(!ReviewStatus %in% c("no assertion provided", "no assertion criteria provided"))
+  dplyr::filter(!ReviewStatus %in% c("no assertion provided", "no assertion criteria provided",
+                                     "no classification for the individual variant", "no classification provided"))
 
 # Load clinVar submission summary file, which reports all submissions for each clinVar variant
 
@@ -106,7 +107,8 @@ submission_summary_df <- vroom(input_submission_file,
     VariationID = as.double(VariationID)
   ) %>%
   dplyr::filter(
-    !ReviewStatus %in% c("no assertion provided", "no assertion criteria provided"),
+    !ReviewStatus %in% c("no assertion provided", "no assertion criteria provided",
+                         "no classification provided"),
     ClinicalSignificance %in% c("Pathogenic", "Likely pathogenic", "Benign", "Likely benign", "Uncertain significance")
   )
 

--- a/scripts/select-clinVar-submissions.R
+++ b/scripts/select-clinVar-submissions.R
@@ -295,7 +295,8 @@ submission_final_df <- variants_no_conflicts %>%
 
 # extract all variants with conflicting interpretations
 clinvar_conflicting <- variant_summary_df %>%
-  dplyr::filter(ReviewStatus == "criteria provided, conflicting interpretations") %>%
+  dplyr::filter(ReviewStatus %in% c("criteria provided, conflicting interpretations",
+                                    "criteria provided, conflicting classifications")) %>%
   pull(VariationID)
 
 # extract all variants with >= P/LP call


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

### Purpose/implementation Section

#### What feature is being added or bug is being addressed?

Closes #242. This PR updates scripts to be compatible with new `ReviewStatus ` nomenclature used to classify variants with conflicting submissions (was `criteria_provided,_conflicting_interpretations`, now `criteria_provided,_conflicting_classifications`). 

#### What was your approach?

For AutoGVP to be compatible with new and old ClinVar version files, I updated code to search for old and new `ReviewStatus` values for conflicting variants. This update was required for the following scripts: 

- `select-clinvar-submission.R`
- `02-annotate_variants_custom_input.R`
- `02-annotate_variants_CAVATICA_input.R`

#### What GitHub issue does your pull request address?

#242 

### Directions for reviewers. Tell potential reviewers what kind of feedback you are soliciting.


#### Which areas should receive a particularly close look?

There is no straight-forward way to test this is working as expected with available data files. A reviewer would need to download latest ClinVar files (05/14/2024 vcf, submission and variant summary) and execute the following: 

`wget https://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh38/clinvar.vcf.gz`

`wget https://ftp.ncbi.nlm.nih.gov/pub/clinvar/tab_delimited/submission_summary.txt.gz`

`wget https://ftp.ncbi.nlm.nih.gov/pub/clinvar/tab_delimited/variant_summary.txt.gz`

`Rscript scripts/select-clinVar-submissions.R --variant_summary data/variant_summary_05142024.txt.gz --submission_summary data/submission_summary_05142024.txt.gz --outdir results --conceptID_list data/clinvar_all_disease_concept_ids.txt --conflict_res "latest"`

```
bash run_autogvp.sh --workflow="custom" \
--vcf=data/test_VEP.vcf \
--clinvar=data/clinvar.vcf.gz \
--intervar=data/test_VEP.hg38_multianno.txt.intervar \
--multianno=data/test_VEP.vcf.hg38_multianno.txt \
--autopvs1=data/test_autopvs1.txt \
--outdir=results \
--out="test_custom_newclinvar" \
--selected_clinvar_submissions=results/ClinVar-selected-submissions.tsv
```

I have confirmed that this code runs as expected with test files, and there are only minor changes compared to previously-generated results that reflect use of a newer ClinVar version with updated submissions. 

#### Is there anything that you want to discuss further?

No

#### Documentation Checklist

<!-- Please review and specify if it isn't applicable -->

- [X] The function has examples to showcase the usage 
- [ ] Added a vignette

