### PR TITLE
Rjcorb/247 add clinvar check

### DIFF
--- a/scripts/02-annotate_variants_CAVATICA_input.R
+++ b/scripts/02-annotate_variants_CAVATICA_input.R
@@ -127,6 +127,7 @@ if (!is.null(input_clinVar_file)) {
         str_detect(INFO, "CLNREVSTAT\\=practice_guideline") ~ "4",
         str_detect(INFO, "CLNREVSTAT\\=criteria_provided,_conflicting_interpretations|CLNREVSTAT\\=criteria_provided,_conflicting_classifications") ~ "1NR",
         str_detect(INFO, "no_assertion|no_interpretation|no_classification") ~ "0",
+        str_detect(INFO, "CLNREVSTAT") ~ "Other"
         TRUE ~ NA_character_
       ),
       ## extract the calls and put in own column
@@ -144,11 +145,18 @@ if (!is.null(input_clinVar_file)) {
         str_detect(INFO, "CLNREVSTAT\\=practice_guideline") ~ "4",
         str_detect(INFO, "CLNREVSTAT\\=criteria_provided,_conflicting_interpretations|CLNREVSTAT\\=criteria_provided,_conflicting_classifications") ~ "1NR",
         str_detect(INFO, "no_assertion|no_interpretation|no_classification") ~ "0",
+        str_detect(INFO, "CLNREVSTAT") ~ "Other",
         TRUE ~ NA_character_
       ),
       ## extract the calls and put in own column
       final_call_clinvar = str_match(INFO, "CLNSIG\\=(\\w+)([\\|\\/]\\w+)*\\;")[, 2]
     )
+}
+
+if (sum(grepl("Other", clinvar_anno_vcf_df$Stars)) > 0){
+  
+  print("ERROR: there are ClinVar review statuses in data that are not recognized by AutoGVP as aligning with star values.\nPlease check that ClinVar review status values match those presented here: https://www.ncbi.nlm.nih.gov/clinvar/docs/review_status/.\nIf no discrepancies exist, please submit an issue through the AutoGVP github here: https://github.com/diskin-lab-chop/AutoGVP/issues")
+  
 }
 
 ## store variants without clinvar info

--- a/scripts/02-annotate_variants_CAVATICA_input.R
+++ b/scripts/02-annotate_variants_CAVATICA_input.R
@@ -126,8 +126,8 @@ if (!is.null(input_clinVar_file)) {
         str_detect(INFO, "CLNREVSTAT\\=reviewed_by_expert_panel") ~ "3",
         str_detect(INFO, "CLNREVSTAT\\=practice_guideline") ~ "4",
         str_detect(INFO, "CLNREVSTAT\\=criteria_provided,_conflicting_interpretations|CLNREVSTAT\\=criteria_provided,_conflicting_classifications") ~ "1NR",
-        str_detect(INFO, "no_assertion|no_interpretation|no_classification") ~ "0",
-        str_detect(INFO, "CLNREVSTAT") ~ "Other"
+        str_detect(INFO, "CLNREVSTAT\\=no_assertion|CLNREVSTAT\\=no_interpretation|CLNREVSTAT\\=no_classification") ~ "0",
+        str_detect(INFO, "CLNREVSTAT") ~ "Other",
         TRUE ~ NA_character_
       ),
       ## extract the calls and put in own column

--- a/scripts/02-annotate_variants_CAVATICA_input.R
+++ b/scripts/02-annotate_variants_CAVATICA_input.R
@@ -153,10 +153,8 @@ if (!is.null(input_clinVar_file)) {
     )
 }
 
-if (sum(grepl("Other", clinvar_anno_vcf_df$Stars)) > 0){
-  
+if (sum(grepl("Other", clinvar_anno_vcf_df$Stars)) > 0) {
   print("ERROR: there are ClinVar review statuses in data that are not recognized by AutoGVP as aligning with star values.\nPlease check that ClinVar review status values match those presented here: https://www.ncbi.nlm.nih.gov/clinvar/docs/review_status/.\nIf no discrepancies exist, please submit an issue through the AutoGVP github here: https://github.com/diskin-lab-chop/AutoGVP/issues")
-  
 }
 
 ## store variants without clinvar info

--- a/scripts/02-annotate_variants_custom_input.R
+++ b/scripts/02-annotate_variants_custom_input.R
@@ -133,11 +133,18 @@ clinvar_anno_vcf_df <- vroom(input_clinVar_file, comment = "#", delim = "\t", co
       str_detect(INFO, "CLNREVSTAT\\=practice_guideline") ~ "4",
       str_detect(INFO, "CLNREVSTAT\\=criteria_provided,_conflicting_interpretations|CLNREVSTAT\\=criteria_provided,_conflicting_classifications") ~ "1NR",
       str_detect(INFO, "no_assertion|no_interpretation|no_classification") ~ "0",
+      str_detect(INFO, "CLNREVSTAT") ~ "Other",
       TRUE ~ NA_character_
     ),
     ## extract the calls and put in own column
     final_call_clinvar = str_match(INFO, "CLNSIG\\=(\\w+)([\\|\\/]\\w+)*\\;")[, 2]
   )
+
+if (sum(grepl("Other", clinvar_anno_vcf_df$Stars)) > 0){
+  
+  print("ERROR: there are ClinVar review statuses in data that are not recognized by AutoGVP as aligning with star values.\nPlease check that ClinVar review status values match those presented here: https://www.ncbi.nlm.nih.gov/clinvar/docs/review_status/.\nIf no discrepancies exist, please submit an issue through the AutoGVP github here: https://github.com/diskin-lab-chop/AutoGVP/issues")
+  
+}
 
 ## store variants without clinvar info
 clinvar_anti_join_vcf_df <- anti_join(vcf_df, clinvar_anno_vcf_df, by = "vcf_id") %>%

--- a/scripts/02-annotate_variants_custom_input.R
+++ b/scripts/02-annotate_variants_custom_input.R
@@ -132,7 +132,7 @@ clinvar_anno_vcf_df <- vroom(input_clinVar_file, comment = "#", delim = "\t", co
       str_detect(INFO, "CLNREVSTAT\\=reviewed_by_expert_panel") ~ "3",
       str_detect(INFO, "CLNREVSTAT\\=practice_guideline") ~ "4",
       str_detect(INFO, "CLNREVSTAT\\=criteria_provided,_conflicting_interpretations|CLNREVSTAT\\=criteria_provided,_conflicting_classifications") ~ "1NR",
-      str_detect(INFO, "no_assertion|no_interpretation|no_classification") ~ "0",
+      str_detect(INFO, "CLNREVSTAT\\=no_assertion|CLNREVSTAT\\=no_interpretation|CLNREVSTAT\\=no_classification") ~ "0",
       str_detect(INFO, "CLNREVSTAT") ~ "Other",
       TRUE ~ NA_character_
     ),

--- a/scripts/02-annotate_variants_custom_input.R
+++ b/scripts/02-annotate_variants_custom_input.R
@@ -140,10 +140,8 @@ clinvar_anno_vcf_df <- vroom(input_clinVar_file, comment = "#", delim = "\t", co
     final_call_clinvar = str_match(INFO, "CLNSIG\\=(\\w+)([\\|\\/]\\w+)*\\;")[, 2]
   )
 
-if (sum(grepl("Other", clinvar_anno_vcf_df$Stars)) > 0){
-  
+if (sum(grepl("Other", clinvar_anno_vcf_df$Stars)) > 0) {
   print("ERROR: there are ClinVar review statuses in data that are not recognized by AutoGVP as aligning with star values.\nPlease check that ClinVar review status values match those presented here: https://www.ncbi.nlm.nih.gov/clinvar/docs/review_status/.\nIf no discrepancies exist, please submit an issue through the AutoGVP github here: https://github.com/diskin-lab-chop/AutoGVP/issues")
-  
 }
 
 ## store variants without clinvar info

--- a/scripts/select-clinVar-submissions.R
+++ b/scripts/select-clinVar-submissions.R
@@ -75,8 +75,10 @@ variant_summary_df <- vroom(input_variant_summary,
       TRUE ~ LastEvaluated
     )
   ) %>%
-  dplyr::filter(!ReviewStatus %in% c("no assertion provided", "no assertion criteria provided",
-                                     "no classification for the individual variant", "no classification provided"))
+  dplyr::filter(!ReviewStatus %in% c(
+    "no assertion provided", "no assertion criteria provided",
+    "no classification for the individual variant", "no classification provided"
+  ))
 
 # Load clinVar submission summary file, which reports all submissions for each clinVar variant
 
@@ -107,8 +109,10 @@ submission_summary_df <- vroom(input_submission_file,
     VariationID = as.double(VariationID)
   ) %>%
   dplyr::filter(
-    !ReviewStatus %in% c("no assertion provided", "no assertion criteria provided",
-                         "no classification provided"),
+    !ReviewStatus %in% c(
+      "no assertion provided", "no assertion criteria provided",
+      "no classification provided"
+    ),
     ClinicalSignificance %in% c("Pathogenic", "Likely pathogenic", "Benign", "Likely benign", "Uncertain significance")
   )
 


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

### Purpose/implementation Section

#### What feature is being added or bug is being addressed?

Closes #247. This PR adds a check to determine if `ReviewStatus` values in ClinVar or sample VCF match those expected by AutoGVP, and throws an error otherwise. 

#### What was your approach?

Updated code in `02_annotate_variants*_input.R` to check for `ReviewStatus` values that are currently not used for star assignment by AutoGVP. 

#### What GitHub issue does your pull request address?

#247 

### Directions for reviewers. Tell potential reviewers what kind of feedback you are soliciting.


#### Which areas should receive a particularly close look?

Let me know if this error message should be updated in any way. 

#### Is there anything that you want to discuss further?


#### Documentation Checklist

<!-- Please review and specify if it isn't applicable -->

- [ ] The function has examples to showcase the usage 
- [ ] Added a vignette

