### PR TITLE
Fix read vcf bug

### DIFF
--- a/scripts/02-annotate_variants_CAVATICA_input.R
+++ b/scripts/02-annotate_variants_CAVATICA_input.R
@@ -1,12 +1,12 @@
 ################################################################################
-# 01-annotate_variants_CAVATICA_input.R
+# 02-annotate_variants_CAVATICA_input.R
 # written by Ammar Naqvi & refactored by Saksham Phul
 #
 # This script annotates variants based on clinVar and integrates a modified
 # version of InterVar that involves adjustments of calls based on ACMG-AMP
 # guidelines
 #
-# usage: Rscript 01-annotate_variants_CAVATICA_input.R --vcf <vcf file>
+# usage: Rscript 02-annotate_variants_CAVATICA_input.R --vcf <vcf file>
 #                                       --intervar <intervar file>
 #                                       --autopvs1 <autopvs1 file>
 #                                       --clinvar  'clinvar_yyyymmdd.vcf.gz'
@@ -104,8 +104,15 @@ address_ambiguous_calls <- function(results_tab_abridged) { ## address ambiguous
   return(results_tab_abridged)
 }
 
+# Open vcf and read lines until a line without '#' is found
+con <- file(input_vcf_file, "r")
+skip_lines <- 0
+while (grepl("^#", readLines(con, n = 1))) {
+  skip_lines <- skip_lines + 1
+}
+
 ## retrieve and store clinVar input file into table
-vcf_df <- vroom(input_vcf_file, comment = "#", delim = "\t", col_names = c("CHROM", "START", "ID", "REF", "ALT", "QUAL", "FILTER", "INFO", "FORMAT", "Sample"), show_col_types = FALSE) %>%
+vcf_df <- vroom(input_vcf_file, skip = skip_lines, delim = "\t", col_names = c("CHROM", "START", "ID", "REF", "ALT", "QUAL", "FILTER", "INFO", "FORMAT", "Sample"), show_col_types = FALSE) %>%
   dplyr::mutate(
     vcf_id = str_remove_all(paste(CHROM, "-", START, "-", REF, "-", ALT), " "),
     vcf_id = str_replace(vcf_id, "chr", "")

--- a/scripts/02-annotate_variants_custom_input.R
+++ b/scripts/02-annotate_variants_custom_input.R
@@ -1,12 +1,12 @@
 ################################################################################
-# 01-annotate_variants_custom_input.R
+# 02-annotate_variants_custom_input.R
 # written by Ammar Naqvi & refactored by Saksham Phul
 #
 # This script annotates variants based on clinVar and integrates a modified
 # version of InterVar that involves adjustments of calls based on ACMG-AMP
 # guidelines
 #
-# usage: Rscript 01-annotate_variants_custom_input.R --vcf <VEP annotated vcf file>
+# usage: Rscript 02-annotate_variants_custom_input.R --vcf <VEP annotated vcf file>
 #                                       --intervar <intervar file>
 #                                       --autopvs1 <autopvs1 file>
 #                                       --multianno <multianno file>
@@ -111,8 +111,15 @@ address_ambiguous_calls <- function(results_tab_abridged) { ## address ambiguous
   return(results_tab_abridged)
 }
 
+# Open vcf and read lines until a line without '#' is found
+con <- file(input_vcf_file, "r")
+skip_lines <- 0
+while (grepl("^#", readLines(con, n = 1))) {
+  skip_lines <- skip_lines + 1
+}
+
 ## make vcf dataframe and add vcf_if column
-vcf_df <- vroom(input_vcf_file, comment = "#", delim = "\t", col_names = c("CHROM", "POS", "ID", "REF", "ALT", "QUAL", "FILTER", "INFO", "FORMAT", "Sample"), trim_ws = TRUE, show_col_types = FALSE) %>%
+vcf_df <- vroom(input_vcf_file, skip = skip_lines, delim = "\t", col_names = c("CHROM", "POS", "ID", "REF", "ALT", "QUAL", "FILTER", "INFO", "FORMAT", "Sample"), trim_ws = TRUE, show_col_types = FALSE) %>%
   mutate(
     vcf_id = str_remove_all(paste(CHROM, "-", POS, "-", REF, "-", ALT), " "),
     vcf_id = str_replace_all(vcf_id, "chr", "")


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

### Purpose/implementation Section

#### What feature is being added or bug is being addressed?

Closes #253. This PR updates `02-annotate_variants_CAVATICA_input.R` and `02-annotate_variants_custom_input.R` to modify how vcf file is loaded. 

#### What was your approach?

Instead of using `comment` argument in `vroom()` to remove characters after `#`, I've updated code to identify number of lines that start with `#` at the beginning of the file, and then using this number to define how many lines to skip when reading VCF. 

#### What GitHub issue does your pull request address?

#253 

### Directions for reviewers. Tell potential reviewers what kind of feedback you are soliciting.


#### Which areas should receive a particularly close look?



#### Is there anything that you want to discuss further?

I don't think this can be tested with any of the test data. However, I have tested this new code on several samples that are affected by this bug. In rare cases there are `#` characters in the `INFO` column, and using the `comment` argument when loading the VCF was causing all characters after the `#` to be excluded when reading into R. As a result, fields from the `Sample` column (AD, DP) were being set to `NA` in final output. Using this updated code has resolved this issue in all tested cases. 

#### Documentation Checklist

<!-- Please review and specify if it isn't applicable -->

- [ ] The function has examples to showcase the usage 
- [ ] Added a vignette

