### PR TITLE
dynamically parse SAMPLE column based on FORMAT fields

### DIFF
--- a/scripts/04-filter_gene_annotations.R
+++ b/scripts/04-filter_gene_annotations.R
@@ -26,24 +26,24 @@ suppressPackageStartupMessages({
 # parse parameters
 option_list <- list(
   make_option(c("--vcf"),
-              type = "character",
-              help = "Input filtered and parsed VEP VCF file"
+    type = "character",
+    help = "Input filtered and parsed VEP VCF file"
   ),
   make_option(c("--autogvp"),
-              type = "character",
-              help = "input AutoGVP annotated file"
+    type = "character",
+    help = "input AutoGVP annotated file"
   ),
   make_option(c("--output"),
-              type = "character", default = "out",
-              help = "output name"
+    type = "character", default = "out",
+    help = "output name"
   ),
   make_option(c("--outdir"),
-              type = "character", default = "results",
-              help = "output directory"
+    type = "character", default = "results",
+    help = "output directory"
   ),
   make_option(c("--default_colnames"),
-              type = "character", default = "data/output_colnames_default.tsv",
-              help = "default output colnames"
+    type = "character", default = "data/output_colnames_default.tsv",
+    help = "default output colnames"
   ),
   make_option(c("--custom_colnames"),
     type = "character", default = NULL,
@@ -75,8 +75,8 @@ csq_fields <- file.path(results_dir, glue::glue("{output_name}.filtered_csq_subf
 
 # Read in VEP vcf file
 vcf <- read_tsv(input_vcf_file,
-                show_col_types = FALSE,
-                guess_max = 10000
+  show_col_types = FALSE,
+  guess_max = 10000
 )
 
 # Remove "[#]" characters from column headers, if present
@@ -119,13 +119,12 @@ vcf_separated <- vcf %>%
 
 # Read in autogvp output
 autogvp <- read_tsv(input_autogvp_file,
-                    show_col_types = FALSE,
-                    guess_max = 10000
+  show_col_types = FALSE,
+  guess_max = 10000
 )
 
 # Parse Sample column, if present
 if ("Sample" %in% names(autogvp)) {
-  
   # write function to parse SAMPLE format fields based on values in each row
   parse_sample <- function(fmt, smp) {
     ff <- strsplit(fmt, ":")[[1]]
@@ -136,16 +135,15 @@ if ("Sample" %in% names(autogvp)) {
     res[missing] <- NA
     as.data.frame(res)
   }
-  
+
   # apply function row-wise
   autogvp_expanded <- dplyr::bind_rows(
     purrr::map2(autogvp$FORMAT, autogvp$Sample, parse_sample)
   )
-  
+
   # merge parsed fields with autogvp df and expand AD column
   autogvp <- bind_cols(autogvp, autogvp_expanded) %>%
     tidyr::separate_wider_delim(AD, delim = ",", names = c("AD_ref", "AD_alt"), too_many = "drop")
-  
 }
 
 # Merge `autogvp` and `vcf_final`
@@ -182,19 +180,18 @@ if ("HGVSc" %in% names(merged_df)) {
 }
 
 if ("HGVSp" %in% names(merged_df)) {
-  
   merged_df <- merged_df %>%
     # rm ensembl transcript/protein IDs from HGVSp columns
     dplyr::mutate(
       HGVSp = case_when(
         grepl(":", HGVSp) ~ str_split(HGVSp, ":", simplify = T)[, 2],
         TRUE ~ HGVSp
-      )) %>%
+      )
+    ) %>%
     # replace `%3D` symbol with `=` in synonymous variant HGVSp
     dplyr::mutate(
       HGVSp = str_replace(HGVSp, "%3D", "=")
     )
-  
 }
 
 split_and_unique <- function(string) {
@@ -204,7 +201,7 @@ split_and_unique <- function(string) {
   unique_values <- unique(split_values[!is.na(split_values)])
   unique_values <- paste(unique_values, collapse = ";")
   unique_values <- unlist(unique_values)
-  
+
   return(unique_values)
 }
 
@@ -247,7 +244,6 @@ if (!is.null(custom_colnames_file)) {
     # remove col_name from default if also in custom to ensure abridged status is defined by user
     dplyr::filter(!Column_name %in% custom_colnames$Column_name) %>%
     bind_rows(custom_colnames)
-  
 } else {
   colnames <- default_colnames
 }


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

### Purpose/implementation Section

#### What feature is being added or bug is being addressed?

Closes #264. This PR updates the `04-filter_gene_annotations.R` to dynamically parse VCF `SAMPLE` values based on fields specified in `FORMAT` for each row. 

#### What was your approach?

* Wrote function to dynamically parse SAMPLE column based on FORMAT fields
* Applied function to all data frame rows to create parsed data frame
* Merged parsed data frame with original autogvp df, and further parsed `AD` column to get ref and alt counts. 

#### What GitHub issue does your pull request address?

#264 

### Directions for reviewers. Tell potential reviewers what kind of feedback you are soliciting.


#### Which areas should receive a particularly close look?



#### Is there anything that you want to discuss further?


#### Documentation Checklist

<!-- Please review and specify if it isn't applicable -->

- [ ] The function has examples to showcase the usage 
- [ ] Added a vignette

