### PR TITLE
V4 data release

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,6 +1,23 @@
 # release notes
 
-## current release (v3)
+## current release (v4)
+- Data release data: 2026-07-20
+- status: available
+
+Updated files:
+- `hgvs4variation-2026-07.txt.gz`; released on ClinVar FTP 2026-07
+- `submission_summary_2026-06.txt.gz`; released on ClinVar FTP 2026-06
+- `variant_summary_2026-06.txt.gz`; released on ClinVar FTP 2026-06
+
+```
+v4
+.
+├── hgvs4variation-2026-07.txt.gz
+├── submission_summary_2026-06.txt.gz
+└── variant_summary_2026-06.txt.gz
+```
+
+## archived release (v3)
 - Data release data: 2026-01-12
 - status: available
 

--- a/scripts/download_db_files.sh
+++ b/scripts/download_db_files.sh
@@ -5,8 +5,8 @@ set -o pipefail
 
 # Use the OpenAUTOGVP bucket as the default.
 URL=${AUTOGVP_URL:-https://bti-openaccess-us-east-1-prd-rokita-lab.s3.us-east-1.amazonaws.com/autogvp}
-RELEASE=${AUTOGVP_RELEASE:-v3}
-CLINVAR_DATE="20260104"
+RELEASE=${AUTOGVP_RELEASE:-v4}
+#CLINVAR_DATE="2026-06"
 
 # Set the working directory to the directory of this file
 cd "$(dirname "${BASH_SOURCE[0]}")"
@@ -30,11 +30,11 @@ cd $BASEDIR/../data
 echo "Checking MD5 hashes..."
 md5sum -c md5sum.txt
 
-echo "Renaming ClinVar files with source date"
-for file in "${FILES[@]}"
-do
-  filename="${file/./_${CLINVAR_DATE}.}"
-  mv -- "$file" "$filename"
-done
+# echo "Renaming ClinVar files with source date"
+# for file in "${FILES[@]}"
+# do
+#   filename="${file/./_${CLINVAR_DATE}.}"
+#   mv -- "$file" "$filename"
+# done
 
 cd $BASEDIR


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

### Purpose/implementation Section

#### What feature is being added or bug is being addressed?

Closes #290. Updates `scripts/download_db_files.sh` to pull v4 data release, which includes June 2026 clinvar variant and submission summary files and hgvs4 variation file from July 2026. 

#### What was your approach?



#### What GitHub issue does your pull request address?

#290 

### Directions for reviewers. Tell potential reviewers what kind of feedback you are soliciting.


#### Which areas should receive a particularly close look?

Please run script and ensure md5sums match. 

#### Is there anything that you want to discuss further?

Can someone confirm that we no longer need the clinvar vcf file in data releases? @jharenza @pj-sullivan 

#### Documentation Checklist

<!-- Please review and specify if it isn't applicable -->

- [X] The function has examples to showcase the usage 
- [ ] Added a vignette

