### PR TITLE
Bug: intervar column as numeric

### DIFF
--- a/scripts/update_intervar.R
+++ b/scripts/update_intervar.R
@@ -55,7 +55,7 @@ output_file <- glue::glue("{basename(intervar_file)}_updated")
 # strings and start is numeric to avoid type mismatches during downstream joins
 intervar_df <- read_tsv(intervar_file, show_col_types = FALSE) %>%
   dplyr::mutate(`#Chr` = as.character(`#Chr`),
-		Start = as.numeric(Start)))
+		Start = as.numeric(Start))
 
 # Parse genomic coordinates from the ClinVar vcf_id field
 # (chr-pos-ref-alt format) into separate columns for variant matching

--- a/scripts/update_intervar.R
+++ b/scripts/update_intervar.R
@@ -54,8 +54,10 @@ output_file <- glue::glue("{basename(intervar_file)}_updated")
 # Load InterVar output and ensure chromosome values are stored as character
 # strings and start is numeric to avoid type mismatches during downstream joins
 intervar_df <- read_tsv(intervar_file, show_col_types = FALSE) %>%
-  dplyr::mutate(`#Chr` = as.character(`#Chr`),
-		Start = as.numeric(Start))
+  dplyr::mutate(
+    `#Chr` = as.character(`#Chr`),
+    Start = as.numeric(Start)
+  )
 
 # Parse genomic coordinates from the ClinVar vcf_id field
 # (chr-pos-ref-alt format) into separate columns for variant matching

--- a/scripts/update_intervar.R
+++ b/scripts/update_intervar.R
@@ -52,9 +52,10 @@ results_dir <- opt$outdir
 output_file <- glue::glue("{basename(intervar_file)}_updated")
 
 # Load InterVar output and ensure chromosome values are stored as character
-# strings to avoid type mismatches during downstream joins
+# strings and start is numeric to avoid type mismatches during downstream joins
 intervar_df <- read_tsv(intervar_file, show_col_types = FALSE) %>%
-  dplyr::mutate(`#Chr` = as.character(`#Chr`))
+  dplyr::mutate(`#Chr` = as.character(`#Chr`),
+		Start = as.numeric(Start)))
 
 # Parse genomic coordinates from the ClinVar vcf_id field
 # (chr-pos-ref-alt format) into separate columns for variant matching


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

### Purpose/implementation Section

#### What feature is being added or bug is being addressed?

Assigning Start to be numeric to avoid the following error:
```
2026-08-13T14:39:20.316169192Z Error in `left_join()`:
2026-08-13T14:39:20.316213229Z ! Can't join `x$Start` with `y$Start_clinvar` due to incompatible types.
2026-08-13T14:39:20.316218739Z ℹ `x$Start` is a <character>.
2026-08-13T14:39:20.316223314Z ℹ `y$Start_clinvar` is a <double>.
```
#### What was your approach?



#### What GitHub issue does your pull request address?
Closes #297 


### Directions for reviewers. Tell potential reviewers what kind of feedback you are soliciting.
Ran on the test set as in the previous PR #292 

```
bash run_autogvp.sh \
--vcf=data/test_pbta.single.vqsr.filtered.vep_105.vcf \
--filter_criteria='FORMAT/DP>=10 (FORMAT/AD[0:1-])/(FORMAT/DP)>=0.08' \
--intervar=data/test_pbta.hg38_multianno.txt.intervar \
--multianno=data/test_pbta.hg38_multianno.txt \
--autopvs1=data/test_pbta.autopvs1.tsv \
--hgvs4variation_file=data/hgvs4variation-2026-07.txt.gz \
--outdir=results \
--out="test_pbta" \
--sample_id="test_pbta" \
--resolved_clinvar=refs/resolved-clinvar-2026-06-cancer-latest.tsv
```

#### Which areas should receive a particularly close look?



#### Is there anything that you want to discuss further?


#### Documentation Checklist

<!-- Please review and specify if it isn't applicable -->

- [ ] The function has examples to showcase the usage 
- [ ] Added a vignette

