### PR TITLE
dedup clinvar IDs for same variant

### DIFF
--- a/scripts/resolve-clinvar-intepretations.R
+++ b/scripts/resolve-clinvar-intepretations.R
@@ -455,6 +455,35 @@ submission_final_df <- submission_final_df %>%
 
 table(submission_final_df$ClinicalSignificance)
 
+# There are rare cases of the same variant having multiple ClinVar VariationIDs
+# We will retain one ID per variant with the most submissions
+# If same submission number, take ID with most stars
+# If same star count, take latest date evaluated
+#
+# Count number of contributing submissions per VariationID
+variation_submission_counts <- submission_summary_df %>%
+  count(VariationID, name = "submission_count")
+
+# Join submission count to final df
+submission_final_df <- submission_final_df %>%
+  left_join(
+    variation_submission_counts,
+    by = "VariationID"
+  ) %>%
+  mutate(
+    submission_count = replace_na(submission_count, 0)
+  )
+
+submission_final_df <- submission_final_df %>%
+  arrange(
+    vcf_id,
+    desc(submission_count),
+    desc(Stars),
+    desc(mdy(LastEvaluated))
+  ) %>%
+  distinct(vcf_id, .keep_all = TRUE) %>%
+  dplyr::select(-submission_count)
+
 write_tsv(
   submission_final_df,
   file.path(results_dir, glue::glue("resolved-clinvar-{date_submission}{concept_label}.tsv"))

--- a/scripts/resolve-clinvar-intepretations.R
+++ b/scripts/resolve-clinvar-intepretations.R
@@ -453,8 +453,6 @@ submission_final_df <- submission_final_df %>%
     TRUE ~ "None"
   ))
 
-table(submission_final_df$ClinicalSignificance)
-
 # There are rare cases of the same variant having multiple ClinVar VariationIDs
 # We will retain one ID per variant with the most submissions
 # If same submission number, take ID with most stars
@@ -483,6 +481,8 @@ submission_final_df <- submission_final_df %>%
   ) %>%
   distinct(vcf_id, .keep_all = TRUE) %>%
   dplyr::select(-submission_count)
+
+table(submission_final_df$ClinicalSignificance)
 
 write_tsv(
   submission_final_df,


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

### Purpose/implementation Section

#### What feature is being added or bug is being addressed?

Closes #301. This PR updates `scripts/resolve-clinvar-intepretations.R` to retain a single ClinVar Variation ID per variant, as there are rare cases where the same variant maps to 2 IDs. 

#### What was your approach?

* For variants with duplicated IDs, retain the ID with: 1) more submissions, 2) higher star count if equal submissions, or 3) with the most recent submission if all else equal. 

#### What GitHub issue does your pull request address?

#301

### Directions for reviewers. Tell potential reviewers what kind of feedback you are soliciting.


#### Which areas should receive a particularly close look?

Run the `resolve-clinvar-interpretations.R` script:

```
Rscript scripts/resolve-clinvar-intepretations.R --variant_summary data/variant_summary_2026-06.txt.gz --submission_summary data/submission_summary_2026-06.txt.gz --outdir refs --conflict_res "latest" --conceptID_list refs/clinvar_cancer_concept_ids_20260130.txt 
```

and confirm that md5sums match: 

```
8821b6a3894783ad20c2a14ff8618976  refs/resolved-clinvar-2026-06-cancer-latest.tsv
```

#### Is there anything that you want to discuss further?

I confirmed that there are 4 fewer rows in the new output file, consistent with the 4 variants with 2 ClinVar IDs that were present in the previous output file (3 VUS in both entries, 1 P in both entries).

```
                           Benign              Benign/Likely benign 
                           209038                             93732 
                    Likely benign                 Likely pathogenic 
                          1098533                            112704 
Likely pathogenic, low penetrance                        Pathogenic 
                               13                            165697 
       Pathogenic, low penetrance      Pathogenic/Likely pathogenic 
                                1                             45791 
                      Risk allele            Uncertain significance 
                               24                           2353009 
                         VUS-high                           VUS-low 
                                1                                 1 
```

#### Documentation Checklist

<!-- Please review and specify if it isn't applicable -->

- [X] The function has examples to showcase the usage 
- [ ] Added a vignette

