### PR TITLE
Skip update_intervar.R if no variants to update

### DIFF
--- a/scripts/update_intervar.R
+++ b/scripts/update_intervar.R
@@ -177,6 +177,16 @@ intervar_missense_df <- intervar_df %>%
 # instead of loading and indexing the entire file in R.
 intervar_ids <- unique(intervar_missense_df$ClinVar_VariationID)
 
+# If no missense variants matched a ClinVar record by position, there is
+# nothing to look up in the HGVS4Variation file and no PS1/PM5 evidence
+# can be updated. Write the input through unchanged and exit early rather
+# than handing vroom an empty pipe further down.
+if (length(intervar_ids) == 0) {
+  print("No ClinVar-matched missense variants found; skipping PS1/PM5 updates.")
+  write_tsv(intervar_df, file.path(results_dir, output_file))
+  quit(save = "no", status = 0)
+}
+
 ids_file <- tempfile()
 writeLines(as.character(intervar_ids), ids_file)
 


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

### Purpose/implementation Section

#### What feature is being added or bug is being addressed?


#### What was your approach?
Added a check to ensure that there were IDs to be pulled from the hgvs4variation file, and if not, exit the update_intervar.R script with a 0 (success) exit code, keeping the file output as the original intervar file.


#### What GitHub issue does your pull request address?
Closes #304 


### Directions for reviewers. Tell potential reviewers what kind of feedback you are soliciting.
I tried this out on the two failing runs, and both returned the result as expected:

```
"No ClinVar-matched missense variants found; skipping PS1/PM5 updates."
```

#### Which areas should receive a particularly close look?



#### Is there anything that you want to discuss further?


#### Documentation Checklist

<!-- Please review and specify if it isn't applicable -->

- [ ] The function has examples to showcase the usage 
- [ ] Added a vignette

